### PR TITLE
fix: resolve all 20 bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ iosApp/                 # iOS app wrapper (Xcode project)
 
 - `components/` — One file per component (Button.kt, Card.kt, etc.)
 - `components/sidebar/` — Sidebar component (multi-file)
-- `components/sooner/` — Sonner toast system (multi-file)
+- `components/sonner/` — Sonner toast system (multi-file)
 - `components/charts/` — Chart components (Bar/Line/Area)
 - `themes/` — KomoTheme, KomoStyles, light/dark colors, radius, typography
 - `utils/` — Shared utilities

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/App.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.Modifier
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.navigation.compose.rememberNavController
-import com.komoui.components.sooner.ObserveAsEvent
-import com.komoui.components.sooner.SonnerHost
-import com.komoui.components.sooner.SonnerProvider
-import com.komoui.components.sooner.showSonner
+import com.komoui.components.sonner.ObserveAsEvent
+import com.komoui.components.sonner.SonnerHost
+import com.komoui.components.sonner.SonnerProvider
+import com.komoui.components.sonner.showSonner
 import com.komoui.themes.KomoTheme
 import com.komoui.demo.navigation.AppNavigation
 import com.komoui.demo.themes.ThemeEvent

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/MainLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/MainLayout.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -52,6 +51,7 @@ import com.komoui.components.Button
 import com.komoui.components.ButtonSize
 import com.komoui.components.ButtonVariant
 import com.komoui.components.Dialog
+import com.komoui.components.DialogTitle
 import com.komoui.components.Input
 import com.komoui.components.sidebar.Sidebar
 import com.komoui.components.sidebar.SidebarCollapsible
@@ -237,6 +237,7 @@ fun MainLayout(rootNav: NavHostController, viewModel: MainViewModel, isDark: Boo
     Dialog(
         open = showDialog,
         onDismissRequest = { showDialog = false },
+        header = { DialogTitle { Text("Search Component") } },
         body = {
             Column(
                 modifier = Modifier
@@ -252,12 +253,14 @@ fun MainLayout(rootNav: NavHostController, viewModel: MainViewModel, isDark: Boo
                     placeholder = "Search components",
                     singleLine = true,
                     trailingIcon = {
-                        Box(
-                            modifier = Modifier.clickable {
-                                showDialog = false
+                        if (searchTxt.isNotBlank()) {
+                            Box(
+                                modifier = Modifier.clickable {
+                                    showDialog = false
+                                }
+                            ) {
+                                Icon(Icons.Default.Close, contentDescription = "close")
                             }
-                        ) {
-                            Icon(Icons.Default.Close, contentDescription = "close")
                         }
                     }
                 )

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/DataTablePage.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/DataTablePage.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.komoui.components.DataTable
 import com.komoui.components.DataTableColumn
-import com.komoui.components.sooner.SonnerProvider
+import com.komoui.components.sonner.SonnerProvider
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.demo.components.ContentPageWithTitle

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/RadioButtonPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/RadioButtonPage.kt
@@ -57,24 +57,16 @@ fun RadioButtonPage() {
                 ) {
                     RadioButtonWithLabel(
                         value = "option-a",
-                        label = "Option A",
-                        selectedValue = selectedOption1,
-                        onValueChange = { selectedOption1 = it })
+                        label = "Option A")
                     RadioButtonWithLabel(
                         value = "option-b",
-                        label = "Option B",
-                        selectedValue = selectedOption1,
-                        onValueChange = { selectedOption1 = it })
+                        label = "Option B")
                     RadioButtonWithLabel(
                         value = "option-c",
-                        label = "Option C",
-                        selectedValue = selectedOption1,
-                        onValueChange = { selectedOption1 = it })
+                        label = "Option C")
                     RadioButtonWithLabel(
                         value = "option-d",
                         label = "Option D (disabled)",
-                        selectedValue = selectedOption1,
-                        onValueChange = { selectedOption1 = it },
                         enabled = false
                     ) // Disabled option
                 }
@@ -106,19 +98,13 @@ fun RadioButtonPage() {
                 ) {
                     RadioButtonWithLabel(
                         value = "radio-1",
-                        label = "Category 1",
-                        selectedValue = selectedOption2,
-                        onValueChange = { selectedOption2 = it })
+                        label = "Category 1")
                     RadioButtonWithLabel(
                         value = "radio-2",
-                        label = "Category 2",
-                        selectedValue = selectedOption2,
-                        onValueChange = { selectedOption2 = it })
+                        label = "Category 2")
                     RadioButtonWithLabel(
                         value = "radio-3",
-                        label = "Category 3",
-                        selectedValue = selectedOption2,
-                        onValueChange = { selectedOption2 = it })
+                        label = "Category 3")
                 }
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/SonnerPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/SonnerPage.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.komoui.components.Button
 import com.komoui.components.ButtonVariant
-import com.komoui.components.sooner.SonnerAction
-import com.komoui.components.sooner.SonnerProvider
+import com.komoui.components.sonner.SonnerAction
+import com.komoui.components.sonner.SonnerProvider
 import com.komoui.demo.components.ContentPageWithTitle
 import com.komoui.demo.components.Layout
 import kotlinx.coroutines.launch

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
@@ -1,7 +1,7 @@
 package com.komoui.components
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -12,7 +12,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -52,38 +51,53 @@ data class AccordionItemData(
 )
 
 /**
- * It allows displaying a list of collapsible items with two expansion modes.
+ * Displays a list of collapsible items with two expansion modes.
+ *
+ * Works uncontrolled by default (seeded from [defaultOpenItemId]); pass [openItems]
+ * together with [onOpenChange] to drive open state from the caller.
  *
  * @param items A list of [AccordionItemData] representing the accordion sections.
  * @param modifier The modifier to be applied to the accordion container.
- * @param defaultOpenItemId The ID of the item that should be open by default. Null if none.
- * @param singleItemExpand When true, only one item can be expanded at a time. When false, multiple items can be expanded.
+ * @param defaultOpenItemId The ID of the item open by default (uncontrolled mode). Null if none.
+ * @param singleItemExpand When true, only one item can be expanded at a time.
+ * @param openItems Controlled set of open item IDs. When non-null the caller owns open state.
+ * @param onOpenChange Invoked with the next set of open item IDs when the user toggles an item.
  */
 @Composable
 fun Accordion(
     items: List<AccordionItemData>,
     modifier: Modifier = Modifier,
     defaultOpenItemId: String? = null,
-    singleItemExpand: Boolean = false
+    singleItemExpand: Boolean = false,
+    openItems: Set<String>? = null,
+    onOpenChange: ((Set<String>) -> Unit)? = null
 ) {
     val styles = MaterialTheme.styles
-    // Use a Set to track multiple expanded items when singleItemExpand is false
-    var expandedItems by remember {
-        mutableStateOf(
-            if (singleItemExpand && defaultOpenItemId != null) setOf(defaultOpenItemId)
-            else if (!singleItemExpand && defaultOpenItemId != null) setOf(defaultOpenItemId)
-            else emptySet()
-        )
+    val chevron = remember(styles.foreground) { chevronDown(styles.foreground) }
+
+    // Uncontrolled state; re-seeded when defaultOpenItemId or singleItemExpand change.
+    var internalOpen by remember(defaultOpenItemId, singleItemExpand) {
+        mutableStateOf(defaultOpenItemId?.let(::setOf) ?: emptySet())
+    }
+    val expandedItems = openItems ?: internalOpen
+
+    fun setOpen(next: Set<String>) {
+        val coerced = if (singleItemExpand) next.take(1).toSet() else next
+        if (openItems == null) internalOpen = coerced
+        onOpenChange?.invoke(coerced)
     }
 
     Column(modifier = modifier.fillMaxWidth()) {
-        items.forEachIndexed { index, item ->
+        items.forEach { item ->
             val isExpanded = expandedItems.contains(item.id)
+            val rotation by animateFloatAsState(
+                targetValue = if (isExpanded) 180f else 0f,
+                animationSpec = tween(300), label = "chevronRotation"
+            )
 
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .animateContentSize(animationSpec = tween(durationMillis = 300))
                     .drawBehind {
                         val strokeWidth = 1.dp.toPx()
                         drawLine(
@@ -102,17 +116,12 @@ fun Accordion(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
                         ) {
-                            if (singleItemExpand) {
-                                // Single item expansion mode
-                                expandedItems = if (isExpanded) emptySet() else setOf(item.id)
+                            val next = if (singleItemExpand) {
+                                if (isExpanded) emptySet() else setOf(item.id)
                             } else {
-                                // Multiple items expansion mode
-                                expandedItems = if (isExpanded) {
-                                    expandedItems - item.id
-                                } else {
-                                    expandedItems + item.id
-                                }
+                                if (isExpanded) expandedItems - item.id else expandedItems + item.id
                             }
+                            setOpen(next)
                         }
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -130,29 +139,11 @@ fun Accordion(
                     }
 
                     Icon(
-                        imageVector = ImageVector.Builder(
-                            name = "ChevronDown",
-                            defaultWidth = 24.dp,
-                            defaultHeight = 24.dp,
-                            viewportWidth = 24f,
-                            viewportHeight = 24f
-                        ).apply {
-                            path(
-                                fill = null,
-                                stroke = SolidColor(styles.foreground),
-                                strokeLineWidth = 2f,
-                                strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
-                                strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round
-                            ) {
-                                moveTo(6f, 9f)
-                                lineTo(12f, 15f)
-                                lineTo(18f, 9f)
-                            }
-                        }.build(),
+                        imageVector = chevron,
                         contentDescription = if (isExpanded) "Collapse" else "Expand",
                         tint = styles.foreground,
                         modifier = Modifier
-                            .rotate(if (isExpanded) 180f else 0f)
+                            .rotate(rotation)
                             .width(24.dp)
                             .height(24.dp)
                     )
@@ -161,16 +152,8 @@ fun Accordion(
                 // Accordion Content
                 AnimatedVisibility(
                     visible = isExpanded,
-                    enter = fadeIn(animationSpec = tween(300)) + expandVertically(
-                        animationSpec = tween(
-                            300
-                        )
-                    ),
-                    exit = fadeOut(animationSpec = tween(300)) + shrinkVertically(
-                        animationSpec = tween(
-                            300
-                        )
-                    )
+                    enter = fadeIn(animationSpec = tween(300)) + expandVertically(animationSpec = tween(300)),
+                    exit = fadeOut(animationSpec = tween(300)) + shrinkVertically(animationSpec = tween(300))
                 ) {
                     Column(
                         modifier = Modifier
@@ -188,10 +171,27 @@ fun Accordion(
                     }
                 }
             }
-            // Add a horizontal line separator between items, except for the last one
-            if (index < items.size - 1) {
-                Spacer(modifier = Modifier.height(0.dp))
-            }
         }
     }
 }
+
+private fun chevronDown(color: androidx.compose.ui.graphics.Color): ImageVector =
+    ImageVector.Builder(
+        name = "ChevronDown",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f
+    ).apply {
+        path(
+            fill = null,
+            stroke = SolidColor(color),
+            strokeLineWidth = 2f,
+            strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
+            strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round
+        ) {
+            moveTo(6f, 9f)
+            lineTo(12f, 15f)
+            lineTo(18f, 9f)
+        }
+    }.build()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
@@ -27,12 +27,12 @@ enum class AlertVariant {
 }
 
 /**
- * Displays a short, important message to the user.
+ * A short, important message.
  *
  * @param modifier The modifier to be applied to the alert container.
  * @param variant The visual style of the alert (Default or Destructive).
- * @param colors that will be used to resolve the colors used for this alert in
- *   different states. See [AlertDefaults.colors].
+ * @param colors The [AlertStyle] resolving the alert's colors. Defaults to
+ *   [AlertDefaults.colors] for [variant]; a caller-supplied value overrides the variant defaults.
  * @param icon Optional icon to display at the start of the alert.
  * @param title The composable content for the alert's title.
  * @param description The composable content for the alert's description.
@@ -41,21 +41,15 @@ enum class AlertVariant {
 fun Alert(
     modifier: Modifier = Modifier,
     variant: AlertVariant = AlertVariant.Default,
-    colors: AlertStyle = AlertDefaults.colors(),
+    colors: AlertStyle = AlertDefaults.colors(variant),
     icon: (@Composable () -> Unit)? = null,
     title: @Composable () -> Unit,
     description: @Composable () -> Unit
 ) {
     val radius = MaterialTheme.radius
-    val titleColor = when (variant) {
-        AlertVariant.Default -> colors.titleColor
-        AlertVariant.Destructive -> MaterialTheme.styles.destructive
-    }
-
-    val descriptionColor = when (variant) {
-        AlertVariant.Default -> colors.descriptionColor
-        AlertVariant.Destructive -> MaterialTheme.styles.destructive.copy(alpha = 0.8f)
-    }
+    // Variant defaults live in AlertDefaults.colors(variant); a caller-supplied AlertStyle wins.
+    val titleColor = colors.titleColor
+    val descriptionColor = colors.descriptionColor
 
     Row(
         modifier = modifier
@@ -101,15 +95,25 @@ data class AlertStyle(
     val descriptionColor: Color
 )
 
+/** Default [AlertStyle]s for [Alert], per [AlertVariant]. */
 object AlertDefaults {
+    /** Theme-derived colors for the given [variant]. Caller overrides take precedence. */
     @Composable
-    fun colors(): AlertStyle {
+    fun colors(variant: AlertVariant = AlertVariant.Default): AlertStyle {
         val styles = MaterialTheme.styles
-        return AlertStyle(
-            borderColors = styles.border,
-            backgroundColor = styles.background,
-            titleColor = styles.foreground,
-            descriptionColor = styles.mutedForeground
-        )
+        return when (variant) {
+            AlertVariant.Default -> AlertStyle(
+                borderColors = styles.border,
+                backgroundColor = styles.background,
+                titleColor = styles.foreground,
+                descriptionColor = styles.mutedForeground
+            )
+            AlertVariant.Destructive -> AlertStyle(
+                borderColors = styles.destructive,
+                backgroundColor = styles.background,
+                titleColor = styles.destructive,
+                descriptionColor = styles.destructive.copy(alpha = 0.8f)
+            )
+        }
     }
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -32,6 +33,8 @@ import com.komoui.themes.styles
  * @param title The composable content for the alert dialog's title.
  * @param description The composable content for the alert dialog's description.
  * @param actions The composable content for the alert dialog's action buttons (e.g., AlertDialogAction, AlertDialogCancel).
+ * @param properties Dialog behavior. Defaults to non-dismissable (no outside-tap / back-press dismiss),
+ * matching shadcn's AlertDialog which can only be dismissed via an explicit action.
  */
 @Composable
 fun AlertDialog(
@@ -40,13 +43,17 @@ fun AlertDialog(
     modifier: Modifier = Modifier,
     title: @Composable () -> Unit,
     description: @Composable () -> Unit,
-    actions: @Composable () -> Unit
+    actions: @Composable () -> Unit,
+    properties: DialogProperties = DialogProperties(
+        dismissOnBackPress = false,
+        dismissOnClickOutside = false
+    )
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
 
     if (open) {
-        Dialog(onDismissRequest = onDismissRequest) {
+        Dialog(onDismissRequest = onDismissRequest, properties = properties) {
             Column(
                 modifier = modifier
                     .fillMaxWidth()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
@@ -13,11 +13,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.styles
@@ -113,11 +113,14 @@ fun Avatar(
 
 @Composable
 private fun AvatarFallbackText(fallbackText: String, size: Dp, styles: KomoStyles) {
+    // Size the initials to the (fixed-dp) avatar via density, not font scale, so they don't
+    // grow past the container and clip when the user enables large system fonts.
+    val fontSize = with(LocalDensity.current) { (size * 0.4f).toSp() }
     Text(
         text = fallbackText,
         style = TextStyle(
             color = styles.mutedForeground,
-            fontSize = (size.value * 0.4).sp,
+            fontSize = fontSize,
             fontWeight = FontWeight.Medium
         )
     )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
@@ -41,16 +41,20 @@ enum class BadgeVariant {
  *   See [BadgeVariant] for available options. Defaults to [BadgeVariant.Default].
  * @param backgroundColor Optional explicit background color for the badge. If null, the color is
  *   determined by the selected [variant] and the current theme.
+ * @param contentColor Optional explicit content (text/icon) color. If null, it is determined by the
+ *   selected [variant] — set this when supplying a custom [backgroundColor] to keep text readable.
  * @param roundedSize The corner radius for the badge's shape. Defaults to a fully rounded shape
  *   (e.g., `Radius.full` which might correspond to `CircleShape` or a large Dp value).
- * @param content A composable lambda defining the content to be displayed inside the badge.
- *   Typically this will be a [androidx.compose.material3.Text] composable.
+ * @param content A composable lambda defining the content to be displayed inside the badge. When
+ *   null the badge renders as a small dot. Typically this will be a
+ *   [androidx.compose.material3.Text] composable.
  */
 @Composable
 fun Badge(
     modifier: Modifier = Modifier,
     variant: BadgeVariant = BadgeVariant.Default,
     backgroundColor: Color? = null,
+    contentColor: Color? = null,
     roundedSize: Dp = MaterialTheme.radius.full,
     content: (@Composable () -> Unit)? = null
 ) {
@@ -63,7 +67,7 @@ fun Badge(
         BadgeVariant.Outline -> styles.background
     }
 
-    val contentColor = when (variant) {
+    val resolvedContentColor = contentColor ?: when (variant) {
         BadgeVariant.Default -> styles.primaryForeground
         BadgeVariant.Secondary -> styles.secondaryForeground
         BadgeVariant.Destructive -> styles.destructiveForeground
@@ -77,22 +81,12 @@ fun Badge(
 
     val size = if (content != null) 16.dp else 6.dp
 
-    val shape = if (content != null) {
-        RoundedCornerShape(roundedSize)
-    } else {
-        CircleShape
-    }
-
-    val borderShape = if (content != null) {
-        RoundedCornerShape(roundedSize)
-    } else {
-        CircleShape
-    }
+    val shape = if (content != null) RoundedCornerShape(roundedSize) else CircleShape
 
     Box(
         modifier = modifier
             .defaultMinSize(minWidth = size, minHeight = size)
-            .background(containerColor, borderShape)
+            .background(containerColor, shape)
             .then(borderStroke?.let { Modifier.border(it, shape) }
                 ?: Modifier) // Apply border if it exists
             .then(
@@ -105,7 +99,7 @@ fun Badge(
         if (content != null) {
             ProvideTextStyle(
                 value = TextStyle(
-                    color = contentColor,
+                    color = resolvedContentColor,
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
                     lineHeight = 16.sp

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -284,7 +284,8 @@ fun Calendar(
 ) {
     val themeColors = MaterialTheme.styles
     val radius = MaterialTheme.radius
-    var currentMonth by remember { mutableStateOf(initialMonth) }
+    // Keyed on initialMonth so the view navigates when the caller changes it after first composition.
+    var currentMonth by remember(initialMonth) { mutableStateOf(initialMonth) }
     val today = remember {
         Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
     }
@@ -538,23 +539,22 @@ fun Calendar(
                                 else -> RoundedCornerShape(radius.sm)
                             }
 
-                            // Only animate for press state; use direct values for other states
-                            val backgroundColor = if (isPressed && isClickable) {
-                                animateColorAsState(
-                                    targetValue = cellBgStyle.onPressed,
-                                    animationSpec = tween(durationMillis = 100),
-                                    label = "dayPressBackground"
-                                ).value
-                            } else {
-                                when {
-                                    isSelected -> cellBgStyle.selectedDate
-                                    isSingleDayRange -> cellBgStyle.rangeEndpointBg
-                                    isRangeStart || isRangeEnd -> cellBgStyle.rangeEndpointBg
-                                    isInRange -> cellBgStyle.inRangeBg
-                                    isToday && isCurrentMonth -> cellBgStyle.todayUnselectedBg
-                                    else -> cellBgStyle.defaultDateCell
-                                }
+                            // Hoisted out of the isPressed branch so the animation persists across
+                            // press/release and actually animates (instead of snapping and disposing).
+                            val targetBackground = when {
+                                isPressed && isClickable -> cellBgStyle.onPressed
+                                isSelected -> cellBgStyle.selectedDate
+                                isSingleDayRange -> cellBgStyle.rangeEndpointBg
+                                isRangeStart || isRangeEnd -> cellBgStyle.rangeEndpointBg
+                                isInRange -> cellBgStyle.inRangeBg
+                                isToday && isCurrentMonth -> cellBgStyle.todayUnselectedBg
+                                else -> cellBgStyle.defaultDateCell
                             }
+                            val backgroundColor = animateColorAsState(
+                                targetValue = targetBackground,
+                                animationSpec = tween(durationMillis = 100),
+                                label = "dayBackground"
+                            ).value
 
                             val textColor = when {
                                 isSelected -> cellTextStyle.selectedDate

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -550,8 +550,14 @@ fun Calendar(
                                 isToday && isCurrentMonth -> cellBgStyle.todayUnselectedBg
                                 else -> cellBgStyle.defaultDateCell
                             }
+                            // Avoid animateColorAsState fading through black: Color.Transparent is
+                            // (0,0,0, alpha 0), so tweening a transparent cell to a light fill (in-range
+                            // accent) passes through muddy grey. Swap a transparent target for a same-hue
+                            // zero-alpha color so transparent<->fill transitions animate alpha only.
+                            val animTarget = if (targetBackground.alpha == 0f)
+                                themeColors.accent.copy(alpha = 0f) else targetBackground
                             val backgroundColor = animateColorAsState(
-                                targetValue = targetBackground,
+                                targetValue = animTarget,
                                 animationSpec = tween(durationMillis = 100),
                                 label = "dayBackground"
                             ).value

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Carousel.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Carousel.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.animation.core.animateDpAsState
 import com.komoui.themes.styles
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
 
 /**
  * Orientation for the Carousel component.
@@ -79,23 +77,26 @@ fun Carousel(
     onItemChanged: ((Int) -> Unit)? = null,
     content: @Composable PagerScope.(position: Int) -> Unit
 ) {
-    val pagerState = state ?: rememberPagerState { itemCount }
+    // rememberPagerState must be called unconditionally (never inside `?:`),
+    // otherwise toggling state null/non-null hits conditional-remember behavior.
+    val internalState = rememberPagerState { itemCount }
+    val pagerState = state ?: internalState
 
     // Invoke onItemChanged callback when the current page changes
     LaunchedEffect(pagerState.currentPage) {
         onItemChanged?.invoke(pagerState.currentPage)
     }
 
-    if (autoScroll && itemCount > 1) {
-        LaunchedEffect(pagerState) {
-            snapshotFlow { pagerState.isScrollInProgress }.collectLatest { scrolling ->
-                if (!scrolling) {
-                    while (true) {
-                        delay(autoScrollDelayMillis)
-                        val nextPage = (pagerState.currentPage + 1) % itemCount
-                        pagerState.animateScrollToPage(nextPage)
-                    }
-                }
+    // Auto-scroll: delay, then advance only if not actively being dragged. Because
+    // animateScrollToPage suspends until it settles, the loop never observes (and so
+    // never cancels) its own in-flight animation. Keyed on all inputs so changes take effect.
+    LaunchedEffect(pagerState, autoScroll, autoScrollDelayMillis, itemCount) {
+        if (!autoScroll || itemCount <= 1) return@LaunchedEffect
+        while (true) {
+            delay(autoScrollDelayMillis)
+            if (!pagerState.isScrollInProgress) {
+                val nextPage = (pagerState.currentPage + 1) % itemCount
+                pagerState.animateScrollToPage(nextPage)
             }
         }
     }
@@ -128,7 +129,8 @@ fun Carousel(
         }
 
         if (showIndicator) {
-            CarouselIndicator(pagerState, itemCount, indicatorStyle)
+            // Use the pager's own page count so an external state and the indicator agree.
+            CarouselIndicator(pagerState, pagerState.pageCount, indicatorStyle)
         }
     }
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
@@ -105,7 +105,8 @@ fun Checkbox(
         if (checked) {
             Icon(
                 imageVector = Icons.Default.Check,
-                contentDescription = "Checked",
+                // Null: the toggleable(role = Role.Checkbox) box already announces checked state.
+                contentDescription = null,
                 tint = checkmarkColor,
                 modifier = Modifier.size(16.dp)
             )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -204,6 +205,8 @@ fun ComboBox(
                             .border(1.dp, styles.border, RoundedCornerShape(radius.lg))
                             .padding(8.dp)
                     ) {
+                        val searchFocusRequester = remember { FocusRequester() }
+                        LaunchedEffect(Unit) { searchFocusRequester.requestFocus() }
                         Input(
                             value = searchText,
                             onValueChange = { searchText = it },
@@ -211,6 +214,7 @@ fun ComboBox(
                             placeholder = "Search options...",
                             leadingIcon = { Icon(Icons.Default.Search, contentDescription = "search") },
                             singleLine = true,
+                            focusRequester = searchFocusRequester,
                         )
 
                         if (filteredOptions.isEmpty()) {
@@ -251,6 +255,7 @@ fun ComboBox(
                                     ) {
                                         Text(
                                             text = option,
+                                            color = if (isSelected) styles.accentForeground else styles.popoverForeground,
                                             fontSize = 14.sp,
                                             modifier = Modifier.weight(1f)
                                         )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -42,23 +42,55 @@ import kotlinx.datetime.LocalDate
 import kotlin.math.roundToInt
 
 class DateFormatter(private val pattern: String) {
+    /**
+     * Formats [date] according to [pattern]. Supported tokens:
+     * `yyyy`/`yy` (year), `MMMM`/`MMM`/`MM`/`M` (month), `dd`/`d` (day of month).
+     * Any other character is emitted verbatim.
+     */
     fun format(date: LocalDate): String {
-        return when (pattern) {
-            "MMM dd, yyyy" -> formatDefault(date)
-            else -> formatDefault(date)
+        val sb = StringBuilder()
+        var i = 0
+        while (i < pattern.length) {
+            val c = pattern[i]
+            if (c == 'y' || c == 'M' || c == 'd') {
+                var j = i
+                while (j < pattern.length && pattern[j] == c) j++
+                sb.append(formatToken(c, j - i, date))
+                i = j
+            } else {
+                sb.append(c)
+                i++
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun formatToken(token: Char, count: Int, date: LocalDate): String {
+        // Month.ordinal is 0-based (JANUARY == 0).
+        val monthIndex = date.month.ordinal
+        return when (token) {
+            'y' -> if (count <= 2) (date.year % 100).toString().padStart(2, '0') else date.year.toString()
+            'M' -> when {
+                count >= 4 -> fullMonths[monthIndex]
+                count == 3 -> shortMonths[monthIndex]
+                count == 2 -> (monthIndex + 1).toString().padStart(2, '0')
+                else -> (monthIndex + 1).toString()
+            }
+            'd' -> if (count >= 2) date.day.toString().padStart(2, '0') else date.day.toString()
+            else -> ""
         }
     }
 
-    private fun formatDefault(date: LocalDate): String {
-        val monthNames = listOf(
+    companion object {
+        private val shortMonths = listOf(
             "Jan", "Feb", "Mar", "Apr", "May", "Jun",
             "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
         )
-        val monthName = monthNames[date.month.ordinal - 1]
-        return "$monthName ${date.day.toString().padStart(2, '0')}, ${date.year}"
-    }
+        private val fullMonths = listOf(
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"
+        )
 
-    companion object {
         fun ofPattern(pattern: String): DateFormatter {
             return DateFormatter(pattern)
         }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -64,7 +64,7 @@ fun Dialog(
                     .background(styles.background, RoundedCornerShape(radius.lg))
                     .border(1.dp, styles.border, RoundedCornerShape(radius.lg))
                     .padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 // Close affordance is always rendered (shadcn always shows the X), even headerless.
                 Row(
@@ -81,9 +81,10 @@ fun Dialog(
                         modifier = Modifier
                             .offset(y = (-16).dp, x = (16).dp),
                     ) {
-                        IconButton(
-                            onClick = onDismissRequest,
-                            size = ButtonSize.IconSm,
+                        Button(
+                            variant = ButtonVariant.Ghost,
+                            size = ButtonSize.Icon,
+                            onClick = onDismissRequest
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Close,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import androidx.compose.ui.window.Dialog as ComposeDialog
+import androidx.compose.ui.window.DialogProperties
 
 /**
  * A Jetpack Compose Dialog component for KomoUI.
@@ -40,6 +41,7 @@ import androidx.compose.ui.window.Dialog as ComposeDialog
  *  typically containing the title (e.g., using [DialogTitle] and [DialogDescription]).
  * @param body The composable content for the dialog's main body (e.g., input fields, lists, etc.).
  * @param footer The composable content for the dialog's footer (e.g., action buttons).
+ * @param properties [DialogProperties] controlling dismiss behavior and platform width.
  */
 @Composable
 fun Dialog(
@@ -48,13 +50,14 @@ fun Dialog(
     modifier: Modifier = Modifier,
     header: (@Composable ColumnScope.() -> Unit)? = null,
     body: (@Composable ColumnScope.() -> Unit)? = null,
-    footer: (@Composable RowScope.() -> Unit)? = null
+    footer: (@Composable RowScope.() -> Unit)? = null,
+    properties: DialogProperties = DialogProperties()
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
 
     if (open) {
-        ComposeDialog(onDismissRequest = onDismissRequest) {
+        ComposeDialog(onDismissRequest = onDismissRequest, properties = properties) {
             Column(
                 modifier = modifier
                     .fillMaxWidth()
@@ -63,31 +66,30 @@ fun Dialog(
                     .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                header?.let {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                            content = it
-                        )
+                // Close affordance is always rendered (shadcn always shows the X), even headerless.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        content = header ?: {}
+                    )
 
-                        Box(
-                            modifier = Modifier
-                                .offset(y = (-16).dp, x = (16).dp),
+                    Box(
+                        modifier = Modifier
+                            .offset(y = (-16).dp, x = (16).dp),
+                    ) {
+                        IconButton(
+                            onClick = onDismissRequest,
+                            size = ButtonSize.IconSm,
                         ) {
-                            IconButton(
-                                onClick = onDismissRequest,
-                                size = ButtonSize.IconSm,
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Close,
-                                    contentDescription = "Close dialog",
-                                    tint = styles.mutedForeground
-                                )
-                            }
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Close",
+                                tint = styles.mutedForeground
+                            )
                         }
                     }
                 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
@@ -25,6 +25,11 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -42,11 +47,17 @@ import com.komoui.themes.styles
  * A Jetpack Compose Drawer (Bottom Sheet) component for KomoUI.
  * Displays a modal bottom sheet with a title, description, and customizable footer.
  *
+ * Closing (whether via [onDismissRequest] or by setting [open] to false) plays the
+ * sheet's exit animation before the content is removed from composition.
+ *
  * @param onDismissRequest Callback invoked when the user tries to dismiss the drawer (e.g., by swiping down or tapping outside).
  * @param open Boolean state controlling the visibility of the drawer.
- * @param modifier The modifier to be applied to the drawer's content area.
  * @param title The composable content for the drawer's title.
  * @param description The composable content for the drawer's description.
+ * @param modifier The modifier to be applied to the drawer's content area.
+ * @param sheetState The [SheetState] controlling the bottom sheet.
+ * @param showCloseButton Whether to render an explicit close (X) button in the header.
+ * @param shouldDismissOnBackPress Whether a back press dismisses the drawer.
  * @param footer The composable content for the drawer's footer (e.g., action buttons).
  * @param content The main content of the drawer, placed between the description and the footer.
  */
@@ -55,18 +66,30 @@ import com.komoui.themes.styles
 fun Drawer(
     onDismissRequest: () -> Unit,
     open: Boolean,
-    modifier: Modifier = Modifier,
-    sheetState: SheetState = rememberModalBottomSheetState(),
     title: @Composable () -> Unit,
     description: @Composable () -> Unit,
-    content: @Composable ColumnScope.() -> Unit,
-    footer: (@Composable RowScope.() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(),
     showCloseButton: Boolean = false,
-    shouldDismissOnBackPress: Boolean = true
+    shouldDismissOnBackPress: Boolean = true,
+    footer: (@Composable RowScope.() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
 ) {
     val styles = MaterialTheme.styles
 
-    if (open) {
+    // Keep the sheet composed until its hide animation finishes, so closing
+    // (programmatic or otherwise) plays the exit animation instead of vanishing.
+    var visible by remember { mutableStateOf(open) }
+    LaunchedEffect(open) {
+        if (open) {
+            visible = true
+        } else if (visible) {
+            sheetState.hide()
+            visible = false
+        }
+    }
+
+    if (visible) {
         ModalBottomSheet(
             onDismissRequest = onDismissRequest,
             sheetState = sheetState,
@@ -127,7 +150,6 @@ fun Drawer(
                     )
                 }
             },
-            modifier = Modifier,
             properties = ModalBottomSheetProperties(shouldDismissOnBackPress),
         ) {
             Column(
@@ -172,7 +194,7 @@ fun Drawer(
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Close,
-                                    contentDescription = "Close dialog",
+                                    contentDescription = "Close",
                                     tint = styles.mutedForeground
                                 )
                             }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DropdownMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DropdownMenu.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem as ComposeDropdownMenuItem
 import androidx.compose.material3.MaterialTheme
@@ -100,7 +101,9 @@ fun DropdownMenuItem(
     val isPressed by interactionSource.collectIsPressedAsState()
 
     val containerColor = animateColorAsState(
-        targetValue = if (isPressed) styles.accent else styles.background,
+        // Transparent (not styles.background) so items match the popover container
+        // on themes where popover != background.
+        targetValue = if (isPressed) styles.accent else Color.Transparent,
         animationSpec = tween(durationMillis = 100), label = "menuItemContainerColor"
     ).value
 
@@ -155,8 +158,8 @@ fun DropdownMenuSeparator(modifier: Modifier = Modifier) {
     Spacer(
         modifier = modifier
             .fillMaxWidth()
+            .padding(vertical = 4.dp)
             .height(1.dp)
             .background(styles.muted)
-            .padding(vertical = 4.dp)
     )
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -57,6 +59,7 @@ enum class InputVariant {
  * @param isError Whether the input field is in an error state.
  * @param visualTransformation The visual transformation to be applied to the input field's text.
  * @param interactionSource The [MutableInteractionSource] that will be used to dispatch events when the input field is interacted with.
+ * @param focusRequester Optional [FocusRequester] attached to the text field so callers can focus it programmatically.
  * @param leadingIcon Optional composable to display at the start of the input field.
  * @param trailingIcon Optional composable to display at the end of the input field.
  * @param singleLine When true, this text field will not allow multiple lines of text.
@@ -79,6 +82,7 @@ fun Input(
     isError: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     interactionSource: MutableInteractionSource? = null,
+    focusRequester: FocusRequester? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     supportingText: @Composable (() -> Unit)? = null,
@@ -142,6 +146,7 @@ fun Input(
             modifier = Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = 44.dp)
+                .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                 .then(borderStyle),
             enabled = enabled,
             readOnly = readOnly,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
@@ -116,7 +116,9 @@ fun Input(
 
     val placeholderColor = colors.placeholder
     val borderStyle = when (variant) {
-        InputVariant.Outlined -> Modifier.border(1.dp, borderColor, RoundedCornerShape(radius.md))
+        InputVariant.Outlined -> Modifier
+            .background(backgroundColor, RoundedCornerShape(radius.md))
+            .border(1.dp, borderColor, RoundedCornerShape(radius.md))
         InputVariant.Underlined -> Modifier.drawBehind {
             val strokeWidth = 1.dp.toPx()
             val y = size.height - strokeWidth / 2
@@ -130,15 +132,16 @@ fun Input(
     }
 
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(modifier)
     ) {
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = 44.dp)
-                .background(backgroundColor, RoundedCornerShape(radius.md))
                 .then(borderStyle),
             enabled = enabled,
             readOnly = readOnly,
@@ -174,7 +177,7 @@ fun Input(
                         modifier = Modifier.weight(1f),
                         contentAlignment = Alignment.CenterStart
                     ) {
-                        if (value.isEmpty() && !isFocused) {
+                        if (value.isEmpty()) {
                             Text(
                                 text = placeholder,
                                 style = TextStyle(
@@ -246,22 +249,7 @@ object InputDefaults {
     }
 
     @Composable
-    fun colors(): InputStyle {
-        val styles = MaterialTheme.styles
-        return InputStyle(
-            background = Color.Unspecified,
-            disableBackground = styles.muted,
-            text = styles.foreground,
-            disableText = styles.mutedForeground,
-            placeholder = styles.mutedForeground.copy(alpha = 0.5f),
-            border = InputBorderStyle(
-                default = styles.input,
-                error = styles.destructive,
-                focus = styles.ring
-            ),
-            supportingText = styles.mutedForeground
-        )
-    }
+    fun colors(): InputStyle = colorsFrom(MaterialTheme.styles)
 
     @Composable
     fun colors(overrides: InputStyle.() -> InputStyle): InputStyle {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -93,6 +95,8 @@ object InputOTPDefaults {
  * @param modifier The modifier applied to the root row.
  * @param length Total number of slots.
  * @param enabled Whether input is enabled.
+ * @param readOnly Whether the field displays its value but rejects edits.
+ * @param focusRequester Optional [FocusRequester] so callers can focus the field programmatically.
  * @param isError Whether the component is in an error state.
  * @param keyboardType Soft-keyboard type. Defaults to [KeyboardType.NumberPassword].
  * @param keyboardActions Keyboard action callbacks (e.g. onDone).
@@ -108,6 +112,8 @@ fun InputOTP(
     modifier: Modifier = Modifier,
     length: Int = 6,
     enabled: Boolean = true,
+    readOnly: Boolean = false,
+    focusRequester: FocusRequester? = null,
     isError: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.NumberPassword,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -118,21 +124,27 @@ fun InputOTP(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
-    val sanitized = value.take(length)
+    // Numeric keyboard types only ever hold digits, applied to both display and input so an
+    // external value with non-digits (or pasted whitespace/emoji) is filtered, not just truncated.
+    val filterForKeyboard: (String) -> String = { raw ->
+        when (keyboardType) {
+            KeyboardType.Number, KeyboardType.NumberPassword, KeyboardType.Decimal ->
+                raw.filter { it.isDigit() }
+            else -> raw
+        }
+    }
+    val sanitized = filterForKeyboard(value).take(length)
 
     BasicTextField(
         value = sanitized,
         onValueChange = { new ->
-            val filtered = when (keyboardType) {
-                KeyboardType.Number, KeyboardType.NumberPassword, KeyboardType.Decimal ->
-                    new.filter { it.isDigit() }
-                else -> new
-            }.take(length)
+            val filtered = filterForKeyboard(new).take(length)
             if (filtered != sanitized) onValueChange(filtered)
         },
-        modifier = modifier,
+        modifier = modifier
+            .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
         enabled = enabled,
-        readOnly = false,
+        readOnly = readOnly,
         textStyle = LocalTextStyle.current.copy(color = Color.Transparent),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         keyboardActions = keyboardActions,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
@@ -9,34 +9,22 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import com.komoui.themes.radius
 import com.komoui.themes.styles
-import kotlin.math.roundToInt
 
-/**
- * A Jetpack Compose Popover component for KomoUI.
- * Displays a floating panel of content (popover) when triggered.
- *
- * @param open Boolean state controlling the visibility of the popover.
- * @param onDismissRequest Callback invoked when the user tries to dismiss the popover (e.g., by tapping outside).
- * @param modifier The modifier to be applied to the popover's content container.
- * @param trigger The composable content that will act as the trigger for the popover.
- * @param content The composable content to display inside the popover.
- */
 @Composable
 fun Popover(
     open: Boolean,
@@ -47,32 +35,35 @@ fun Popover(
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
-    var triggerWidthPx by remember { mutableIntStateOf(0) }
-    var triggerHeightPx by remember { mutableIntStateOf(0) }
-    var triggerXPositionPx by remember { mutableIntStateOf(0) }
-    var triggerYPositionPx by remember { mutableIntStateOf(0) }
+    val gapPx = with(LocalDensity.current) { 8.dp.roundToPx() }
 
-    Column {
-        Box(
-            modifier = Modifier.onGloballyPositioned { coordinates ->
-                triggerWidthPx = coordinates.size.width
-                triggerHeightPx = coordinates.size.height
-                val position = coordinates.parentLayoutCoordinates?.windowToLocal(coordinates.positionInWindow())
-                triggerXPositionPx = position?.x?.roundToInt() ?: 0
-                triggerYPositionPx = position?.y?.roundToInt() ?: 0
+    // Centers the popup horizontally under the anchor using the measured popup size,
+    // so true centering works regardless of density or popup width.
+    val positionProvider = remember(gapPx) {
+        object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize
+            ): IntOffset {
+                val x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
+                val y = anchorBounds.bottom + gapPx
+                return IntOffset(x, y)
             }
-        ) {
-            trigger()
         }
+    }
+
+    Box {
+        trigger()
 
         if (open) {
             Popup(
-                onDismissRequest = onDismissRequest,
-                alignment = Alignment.TopStart,
-                offset = IntOffset((triggerXPositionPx - triggerWidthPx) / 2, triggerYPositionPx + triggerHeightPx + 12)
+                popupPositionProvider = positionProvider,
+                onDismissRequest = onDismissRequest
             ) {
                 Box(
-                    modifier = Modifier.shadow(1.dp, RoundedCornerShape(radius.md)) // shadow-md
+                    modifier = Modifier.shadow(4.dp, RoundedCornerShape(radius.md))
                 ) {
                     Column(
                         modifier = modifier

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Progress.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Progress.kt
@@ -18,6 +18,15 @@ import androidx.compose.ui.unit.dp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
+/**
+ * A determinate linear progress bar.
+ *
+ * @param progress Completion fraction in 0..1 (values outside are coerced). Changes animate.
+ * @param modifier The modifier to be applied to the progress bar container.
+ * @param height The thickness of the bar.
+ * @param trackColor The color of the unfilled track.
+ * @param indicatorColor The color of the filled portion.
+ */
 @Composable
 fun Progress(
     progress: Float,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonColors
@@ -24,36 +25,47 @@ import androidx.compose.ui.unit.sp
 import com.komoui.themes.styles
 
 /**
+ * Scope exposed to a [RadioGroup]'s content. Carries the group's current selection
+ * so child [RadioButtonWithLabel]s stay in sync without re-passing selection state.
+ */
+class RadioGroupScope<T> internal constructor(
+    val selectedValue: T,
+    val onValueChange: (T) -> Unit
+)
+
+/**
  * A Jetpack Compose Radio Group component for KomoUI.
- * It manages the selection state for a group of [RadioButtonWithLabel]s.
+ * It owns the selection state for a group of [RadioButtonWithLabel]s and exposes it
+ * to children via [RadioGroupScope]. The container is marked as a mutually-exclusive
+ * selectable group for accessibility.
  *
  * @param selectedValue The currently selected value in the group.
  * @param onValueChange Callback invoked when the selection changes. Provides the new selected value.
  * @param modifier The modifier to be applied to the radio group container.
- * @param content The composable content representing the radio buttons and their labels.
- * Each radio button should be wrapped in a selectable row with its label.
  * @param orientation The orientation of the radio group (horizontal or vertical).
+ * @param content The radio buttons, typically [RadioButtonWithLabel]s, composed within [RadioGroupScope].
  */
 @Composable
 fun <T> RadioGroup(
     selectedValue: T,
     onValueChange: (T) -> Unit,
     modifier: Modifier = Modifier,
-    orientation: LayoutOrientation = LayoutOrientation.Vertical, // New parameter for orientation
-    content: @Composable () -> Unit
+    orientation: LayoutOrientation = LayoutOrientation.Vertical,
+    content: @Composable RadioGroupScope<T>.() -> Unit
 ) {
+    val scope = RadioGroupScope(selectedValue, onValueChange)
     when (orientation) {
         LayoutOrientation.Vertical -> Column(
-            modifier = modifier,
+            modifier = modifier.selectableGroup(),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            content()
+            scope.content()
         }
         LayoutOrientation.Horizontal -> Row(
-            modifier = modifier,
+            modifier = modifier.selectableGroup(),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            content()
+            scope.content()
         }
     }
 }
@@ -68,22 +80,19 @@ enum class LayoutOrientation {
 
 /**
  * A convenience composable to combine a native [RadioButton] with a [Text] label,
- * with the KomoUI design tokens. This should be used as a child within a [RadioGroup].
+ * with the KomoUI design tokens. Must be composed within a [RadioGroup]'s content,
+ * from which it reads the current selection and reports changes.
  *
  * @param value The value associated with this radio button.
  * @param label The text label for this radio button.
- * @param selectedValue The currently selected value of the parent group.
- * @param onValueChange The callback for when this radio button is selected.
  * @param modifier The modifier to be applied to the row containing the radio button and label.
  * @param enabled Controls the enabled state of the radio button and label.
  * @param colors Optional custom colors for the radio button and label.
  */
 @Composable
-fun <T> RadioButtonWithLabel(
+fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
     value: T,
     label: String,
-    selectedValue: T,
-    onValueChange: (T) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     colors: RadioButtonColors? = null

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -3,6 +3,7 @@ package com.komoui.components
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -148,7 +149,7 @@ fun <T> Select(
                 )
                 Icon(
                     imageVector = Icons.Default.KeyboardArrowDown,
-                    contentDescription = "Dropdown arrow",
+                    contentDescription = null,
                     tint = styles.mutedForeground,
                     modifier = Modifier
                         .size(20.dp)
@@ -165,8 +166,11 @@ fun <T> Select(
                 properties = PopupProperties(focusable = true), // Make popup focusable to handle outside clicks
                 onDismissRequest = { expanded = false }
             ) {
+                // Drive visibility from false -> true after composition so the enter transition plays.
+                val transitionState = remember { MutableTransitionState(false) }
+                transitionState.targetState = true
                 AnimatedVisibility(
-                    visible = true,
+                    visibleState = transitionState,
                     enter = fadeIn(animationSpec = tween(150)) + expandVertically(animationSpec = tween(150))
                 ) {
                     // Dropdown content container

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Skeleton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Skeleton.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
 import com.komoui.themes.radius
@@ -29,16 +30,16 @@ import com.komoui.themes.styles
  * Displays a placeholder loading state with a shimmer effect.
  *
  * @param modifier The modifier to be applied to the skeleton container.
- * @param shape The shape of the skeleton. Defaults to `RoundedCornerShape(Radius.md)`.
+ * @param shape The [Shape] of the skeleton (e.g. `CircleShape` for avatars). Defaults to `RoundedCornerShape(radius.md)`.
  * @param baseColor The base background color of the skeleton. Defaults to `MaterialTheme.styles.muted`.
- * @param shimmerColor The color of the shimmering highlight. Defaults to `MaterialTheme.styles.background.copy(alpha = 0.8f)`.
+ * @param shimmerColor The color of the shimmering highlight. Defaults to `MaterialTheme.styles.muted.copy(alpha = 0.5f)`.
  * @param animationDurationMillis The duration of one shimmer cycle in milliseconds.
  * @param gradientWidthRatio The ratio of the shimmer gradient's width to the skeleton's width.
  */
 @Composable
 fun Skeleton(
     modifier: Modifier = Modifier,
-    shape: RoundedCornerShape = RoundedCornerShape(MaterialTheme.radius.md),
+    shape: Shape = RoundedCornerShape(MaterialTheme.radius.md),
     baseColor: Color = MaterialTheme.styles.muted,
     shimmerColor: Color = MaterialTheme.styles.muted.copy(alpha = 0.5f),
     animationDurationMillis: Int = 1500,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
@@ -20,18 +20,6 @@ import androidx.compose.ui.unit.dp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
-/**
- * A Jetpack Compose Slider component for KomoUI.
- * Allows users to select a value from a continuous range.
- *
- * @param value The current value of the slider.
- * @param onValueChange Callback invoked when the slider's value changes.
- * @param modifier The modifier to be applied to the slider.
- * @param valueRange The range of values the slider can take.
- * @param steps The number of discrete steps the slider can take.
- * @param enabled Controls the enabled state of the slider.
- * @param colors Optional custom colors for the slider.
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Slider(
@@ -48,9 +36,11 @@ fun Slider(
     ComposeSlider(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier
+        // Defaults before the caller modifier so a caller can size the slider (narrower/taller).
+        modifier = Modifier
             .fillMaxWidth()
-            .height(20.dp),
+            .height(20.dp)
+            .then(modifier),
         valueRange = valueRange,
         steps = steps,
         enabled = enabled,
@@ -58,28 +48,28 @@ fun Slider(
             thumbColor = themeColors.background,
             activeTrackColor = themeColors.primary,
             inactiveTrackColor = themeColors.secondary,
-            activeTickColor = themeColors.primaryForeground.copy(alpha = 0.5f),
-            inactiveTickColor = themeColors.secondaryForeground.copy(alpha = 0.5f),
             disabledThumbColor = themeColors.mutedForeground.copy(alpha = 0.5f),
             disabledActiveTrackColor = themeColors.primary.copy(alpha = 0.5f),
-            disabledInactiveTrackColor = themeColors.secondary.copy(alpha = 0.5f),
-            disabledActiveTickColor = themeColors.primaryForeground.copy(alpha = 0.2f),
-            disabledInactiveTickColor = themeColors.secondaryForeground.copy(alpha = 0.2f)
+            disabledInactiveTrackColor = themeColors.secondary.copy(alpha = 0.5f)
         ),
         thumb = {
+            val borderColor = if (enabled) themeColors.primary else themeColors.primary.copy(alpha = 0.5f)
             Box(
                 modifier = Modifier
                     .size(20.dp)
                     .clip(CircleShape)
                     .background(themeColors.background)
-                    .border(2.dp, themeColors.primary, CircleShape)
+                    .border(2.dp, borderColor, CircleShape)
             )
         },
-        track = { sliderPositions ->
+        track = {
             val trackColor = if (enabled) themeColors.secondary else themeColors.secondary.copy(alpha = 0.5f)
             val activeTrackColor = if (enabled) themeColors.primary else themeColors.primary.copy(alpha = 0.5f)
-            // Calculate the fraction of the active track based on value and valueRange
-            val activeTrackWidthFraction = (value - valueRange.start) / (valueRange.endInclusive - valueRange.start)
+            // Fraction of the active track; guard the empty range and clamp out-of-range values,
+            // since fillMaxWidth() requires a 0..1 fraction.
+            val span = valueRange.endInclusive - valueRange.start
+            val activeTrackWidthFraction =
+                if (span == 0f) 0f else ((value - valueRange.start) / span).coerceIn(0f, 1f)
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
@@ -78,13 +78,21 @@ fun Switch(
         modifier = modifier
             .size(width = switchWidth, height = switchHeight)
             .border(1.dp, borderColor.copy(alpha = if (enabled) 1f else disabledAlpha), CircleShape)
-            .toggleable(
-                value = checked,
-                onValueChange = onCheckedChange ?: { /* do nothing if null */ },
-                enabled = enabled,
-                role = Role.Switch,
-                interactionSource = interactionSource,
-                indication = null
+            // A null callback means the parent owns interaction (e.g. a clickable labeled row):
+            // drop our own click handling and toggleable semantics entirely.
+            .then(
+                if (onCheckedChange != null) {
+                    Modifier.toggleable(
+                        value = checked,
+                        onValueChange = onCheckedChange,
+                        enabled = enabled,
+                        role = Role.Switch,
+                        interactionSource = interactionSource,
+                        indication = null
+                    )
+                } else {
+                    Modifier
+                }
             )
             .drawBehind {
                 val trackCornerRadius = CornerRadius(switchHeight.toPx() / 2f)

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
@@ -332,8 +332,9 @@ fun PaginationScope.DefaultPagination() {
  * @param pageSize Rows per page.
  * @param initialSort Initial sort state.
  * @param onSortChange Observer callback fired when sort changes.
- * @param onSelectionChange Observer callback fired when selection changes. Items are compared
- *      by [rowKey] — two items with the same key are treated as the same row.
+ * @param onSelectionChange Observer callback fired when selection changes. Emits the set of
+ *      selected [rowKey] values, so selection survives item-instance refreshes and never
+ *      contains duplicates for the same row.
  * @param onRowClick Optional row click handler.
  * @param caption Optional caption text rendered below the table.
  * The footer below the table is laid out as two rows: a summary row showing "N of M
@@ -356,7 +357,7 @@ fun <T> DataTable(
     pageSize: Int = 10,
     initialSort: SortState = SortState(),
     onSortChange: ((SortState) -> Unit)? = null,
-    onSelectionChange: ((Set<T>) -> Unit)? = null,
+    onSelectionChange: ((Set<Any>) -> Unit)? = null,
     onRowClick: ((T) -> Unit)? = null,
     caption: String? = null,
     pagination: @Composable PaginationScope.() -> Unit = { DefaultPagination() }
@@ -369,13 +370,12 @@ fun <T> DataTable(
         onSortChange?.invoke(next)
     }
 
-    var selection by remember { mutableStateOf<Set<T>>(emptySet()) }
-    val updateSelection: (Set<T>) -> Unit = { next ->
-        selection = next
+    // Selection is stored by rowKey, not item instance, so it survives item refreshes
+    // and can never hold two entries for the same row.
+    var selectedKeySet by remember { mutableStateOf<Set<Any>>(emptySet()) }
+    val updateSelection: (Set<Any>) -> Unit = { next ->
+        selectedKeySet = next
         onSelectionChange?.invoke(next)
-    }
-    val selectedKeySet: Set<Any> = remember(selection) {
-        selection.mapTo(mutableSetOf(), rowKey)
     }
 
     val sorted = remember(items, sort, columns) {
@@ -433,11 +433,11 @@ fun <T> DataTable(
                             Checkbox(
                                 checked = allOnPageSelected,
                                 onCheckedChange = { checked ->
-                                    val next = selection.toMutableSet()
+                                    val next = selectedKeySet.toMutableSet()
                                     if (checked) {
-                                        next.addAll(pageItems)
+                                        next.addAll(pageKeys)
                                     } else {
-                                        next.removeAll { rowKey(it) in pageKeys }
+                                        next.removeAll(pageKeys)
                                     }
                                     updateSelection(next)
                                 }
@@ -500,11 +500,11 @@ fun <T> DataTable(
                                     Checkbox(
                                         checked = isSelected,
                                         onCheckedChange = { checked ->
-                                            val next = selection.toMutableSet()
+                                            val next = selectedKeySet.toMutableSet()
                                             if (checked) {
-                                                next.add(item)
+                                                next.add(key)
                                             } else {
-                                                next.removeAll { rowKey(it) == key }
+                                                next.remove(key)
                                             }
                                             updateSelection(next)
                                         }
@@ -538,7 +538,7 @@ fun <T> DataTable(
         ) {
             if (enableSelection) {
                 Text(
-                    text = "${selection.size} of ${sorted.size} row(s) selected.",
+                    text = "${selectedKeySet.size} of ${sorted.size} row(s) selected.",
                     color = styles.mutedForeground,
                     style = MaterialTheme.typography.bodySmall
                 )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
@@ -1,6 +1,6 @@
 package com.komoui.components
 
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -14,14 +14,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -154,41 +150,4 @@ fun TabsContent(
     ) {
         content()
     }
-}
-
-/**
- * Helper function to create animated color state
- */
-@Composable
-private fun animateColorAsState(
-    targetValue: Color,
-    animationSpec: androidx.compose.animation.core.AnimationSpec<Float> = tween(),
-    label: String = "ColorAnimation"
-): State<Color> {
-    val red by animateFloatAsState(
-        targetValue = targetValue.red,
-        animationSpec = animationSpec,
-        label = "${label}_red"
-    )
-    val green by animateFloatAsState(
-        targetValue = targetValue.green,
-        animationSpec = animationSpec,
-        label = "${label}_green"
-    )
-    val blue by animateFloatAsState(
-        targetValue = targetValue.blue,
-        animationSpec = animationSpec,
-        label = "${label}_blue"
-    )
-    val alpha by animateFloatAsState(
-        targetValue = targetValue.alpha,
-        animationSpec = animationSpec,
-        label = "${label}_alpha"
-    )
-
-    val colorState = remember(red, green, blue, alpha) {
-        derivedStateOf { Color(red, green, blue, alpha) }
-    }
-
-    return colorState
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
@@ -138,8 +138,12 @@ fun SidebarProvider(
             LocalSidebarState provides state,
             LocalSidebarSlots provides slots,
         ) {
-            slots.sidebar = null
-            slots.inset = null
+            // intentionally NOT reset to null here. Nulling every recomposition
+            // blanks the layout when a child (Sidebar/SidebarInset) skips re-registration —
+            // the snapshot-backed slot invalidates the reader, which then renders null.
+            // A skipping child means its content is unchanged, so its last lambda is still
+            // valid. Add DisposableEffect-based clearing only if a conditionally-mounted
+            // Sidebar/SidebarInset use case appears.
             // Children (Sidebar, SidebarInset) register their content into `slots` and emit nothing.
             content()
             // Render the captured slots in the layout appropriate for the viewport.

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -93,11 +94,14 @@ fun SidebarProvider(
         if (!isMobile) openMobile = false
     }
 
+    // Kept out of the remember keys so an inline (non-remembered) callback doesn't rebuild
+    // SidebarState on every recomposition; the state's captured lambda reads the latest.
+    val onOpenChangeState = rememberUpdatedState(onOpenChange)
     val state = remember(
         isMobile, side, variant, collapsible,
         effectiveOpen, openMobile,
         width, widthMobile, widthIcon, animationSpec,
-        controlled, onOpenChange,
+        controlled,
     ) {
         SidebarState(
             isMobile = isMobile,
@@ -111,7 +115,7 @@ fun SidebarProvider(
             widthIcon = widthIcon,
             animationSpec = animationSpec,
             onOpenChange = { next ->
-                if (controlled) onOpenChange?.invoke(next) else internalOpen = next
+                if (controlled) onOpenChangeState.value?.invoke(next) else internalOpen = next
             },
             onOpenMobileChange = { next -> openMobile = next },
         )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
@@ -5,6 +5,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -123,10 +126,13 @@ val LocalSidebarState = compositionLocalOf<SidebarState> {
  * layout position (Row on desktop, ModalNavigationDrawer on mobile).
  */
 internal class SidebarSlots {
-    var sidebar: (@Composable () -> Unit)? = null
-    var inset: (@Composable () -> Unit)? = null
+    // Snapshot-backed so that when a slot is (re)registered in one recompose scope, the
+    // reader scope (SidebarLayoutImpl / SidebarShell) is invalidated instead of rendering
+    // a stale captured lambda.
+    var sidebar: (@Composable () -> Unit)? by mutableStateOf(null)
+    var inset: (@Composable () -> Unit)? by mutableStateOf(null)
     /** Set by [SidebarRail] to opt the sidebar shell into rendering an outer-edge rail. */
-    var railEnabled: Boolean = false
+    var railEnabled: Boolean by mutableStateOf(false)
 }
 
 internal val LocalSidebarSlots = compositionLocalOf<SidebarSlots?> { null }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -108,8 +107,13 @@ class SidebarState internal constructor(
     internal fun setOpenMobile(open: Boolean) = onOpenMobileChange(open)
 }
 
-/** Provides the active [SidebarState]. Throws when used outside a [SidebarProvider]. */
-val LocalSidebarState = staticCompositionLocalOf<SidebarState> {
+/**
+ * Provides the active [SidebarState]. Throws when used outside a [SidebarProvider].
+ *
+ * Read-tracking (`compositionLocalOf`, not `staticCompositionLocalOf`): a new state on
+ * toggle recomposes only the composables that actually read it, not the whole subtree.
+ */
+val LocalSidebarState = compositionLocalOf<SidebarState> {
     error("SidebarState not provided. Wrap your content in SidebarProvider.")
 }
 

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/ObserveAsEvent.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/ObserveAsEvent.kt
@@ -1,4 +1,4 @@
-package com.komoui.components.sooner
+package com.komoui.components.sonner
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -1,4 +1,4 @@
-package com.komoui.components.sooner
+package com.komoui.components.sonner
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerHost.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerHost.kt
@@ -1,4 +1,4 @@
-package com.komoui.components.sooner
+package com.komoui.components.sonner
 
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerProvider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerProvider.kt
@@ -1,4 +1,4 @@
-package com.komoui.components.sooner
+package com.komoui.components.sonner
 
 import androidx.compose.material3.SnackbarDuration
 import kotlinx.coroutines.channels.Channel

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerProvider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerProvider.kt
@@ -41,7 +41,9 @@ data class SonnerAction(
  * Use [showMessage] for informational notifications and [showError] for error/destructive notifications.
  */
 object SonnerProvider {
-    private val _events = Channel<SonnerEvent>()
+    // Buffered so show* callers don't suspend indefinitely when no host is
+    // collecting (e.g. app backgrounded and repeatOnLifecycle cancelled collection).
+    private val _events = Channel<SonnerEvent>(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     private suspend fun show(

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
@@ -43,11 +43,13 @@ data class SonnerVisualsImpl(
  *
  * Converts a [SonnerEvent] into [SonnerVisualsImpl] and shows it using the host state.
  *
+ * When the user taps the action button, the event's [SonnerAction.execute] callback is invoked.
+ *
  * @param event The [SonnerEvent] containing the message, variant, and action configuration.
  * @return The [SnackbarResult] indicating whether the snackbar was dismissed or the action was performed.
  */
 suspend fun SnackbarHostState.showSonner(event: SonnerEvent): SnackbarResult {
-    return showSnackbar(SonnerVisualsImpl(
+    val result = showSnackbar(SonnerVisualsImpl(
         message = event.message,
         subMessage = event.subMessage,
         actionLabel = event.action?.actionText,
@@ -55,4 +57,8 @@ suspend fun SnackbarHostState.showSonner(event: SonnerEvent): SnackbarResult {
         duration = event.duration,
         variant = event.variant
     ))
+    if (result == SnackbarResult.ActionPerformed) {
+        event.action?.execute?.invoke()
+    }
+    return result
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
@@ -1,4 +1,4 @@
-package com.komoui.components.sooner
+package com.komoui.components.sonner
 
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState

--- a/komoui/src/commonTest/kotlin/com/komoui/components/DateFormatterTest.kt
+++ b/komoui/src/commonTest/kotlin/com/komoui/components/DateFormatterTest.kt
@@ -1,0 +1,36 @@
+package com.komoui.components
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateFormatterTest {
+
+    private val expectedShort = listOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    )
+
+    @Test
+    fun allMonthsFormatWithCorrectShortName() {
+        val formatter = DateFormatter.ofPattern("MMM dd, yyyy")
+        for (month in 1..12) {
+            val date = LocalDate(2024, month, 5)
+            assertEquals("${expectedShort[month - 1]} 05, 2024", formatter.format(date))
+        }
+    }
+
+    @Test
+    fun januaryDoesNotCrashAndShowsJan() {
+        val formatter = DateFormatter.ofPattern("MMM dd, yyyy")
+        assertEquals("Jan 01, 2024", formatter.format(LocalDate(2024, 1, 1)))
+    }
+
+    @Test
+    fun patternIsHonored() {
+        val date = LocalDate(2024, 3, 9)
+        assertEquals("2024-03-09", DateFormatter.ofPattern("yyyy-MM-dd").format(date))
+        assertEquals("March 9", DateFormatter.ofPattern("MMMM d").format(date))
+        assertEquals("09/03/24", DateFormatter.ofPattern("dd/MM/yy").format(date))
+    }
+}


### PR DESCRIPTION
Fixes all 20 `bug`

## Issues

- DatePicker — 0-based `Month.ordinal` caused a January crash and off-by-one month names; also made `DateFormatter` honor its pattern (token parser) + tests for all 12 months
- AlertDialog — non-dismissable by outside tap / back press (exposed `properties`)
- Switch — drop toggleable semantics + click handling when `onCheckedChange` is null
- Input — apply caller modifier to root; keep placeholder visible on focus; underlined variant no longer gets a rounded background
- Popover — real centering via `PopupPositionProvider`; density-correct gap
- RadioGroup — group now owns selection via `RadioGroupScope`; added `selectableGroup()`; removed dead child params
- Accordion — controllable state that resyncs on param change; cached chevron vector; animated rotation; removed double animation + dead code
- renamed misspelled `components.sooner` package → `components.sonner` (**breaking**)
- Sonner — buffered event channel (no more hung callers); `action.execute` now fires on action tap
- Drawer — animates exit via `sheetState.hide()`; reordered params so `content` is a trailing lambda (**breaking**)
- Carousel — fixed auto-scroll self-cancel; keyed effect on all inputs; unconditional `rememberPagerState`; indicator uses `pageCount`
- DataTable — selection keyed by `rowKey` (survives refreshes, no duplicates); `onSelectionChange` now emits `Set<Any>` (**breaking**)
- Sidebar — `compositionLocalOf` (was `staticCompositionLocalOf`, recomposed whole subtree); `rememberUpdatedState` for `onOpenChange`
- Sidebar — slot registry backed by snapshot state to fix stale renders
- Slider — guarded/coerced fraction math; caller-overridable size; removed dead tick colors; thumb honors `enabled`
- Tabs — replaced hand-rolled channel-lerp with `androidx.compose.animation.animateColorAsState`
- Calendar — `initialMonth` changes now navigate; day press animation actually animates
- Select/Combobox — real enter animation; selected-text contrast; search autofocus (added `focusRequester` to `Input`)
- DropdownMenu — transparent unpressed items; separators get real spacing
- Misc — Alert (variant colors via defaults), Dialog (always-render close X + `DialogProperties`), Badge (`contentColor`), Checkbox (null a11y label), InputOTP (digit filtering + `readOnly`/`focusRequester`), Skeleton (`Shape`), Progress (KDoc), Avatar (density-scaled initials)