### PR TITLE
fix: modifier must start the root chain

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/CardPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/CardPage.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -59,9 +60,10 @@ fun CardPage(nav: NavHostController) {
                 modifier = Modifier.border(0.dp, Color.Unspecified)
             ) {
                 AsyncImage(
-                    "https://heroui.com/images/hero-card.jpeg",
-                    contentDescription = "",
-                    modifier = Modifier.size(200.dp)
+                    "https://img.magnific.com/free-photo/young-woman-listening-music-home_23-2149029679.jpg",
+                    contentDescription = "sample image",
+                    modifier = Modifier.size(200.dp),
+                    contentScale = ContentScale.Crop
                 )
             }
         }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
@@ -56,11 +56,10 @@ fun Avatar(
     val styles = MaterialTheme.styles
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .size(size)
             .clip(CircleShape)
-            .border(1.dp, styles.border, CircleShape)
-            .then(modifier),
+            .border(1.dp, styles.border, CircleShape),
         contentAlignment = Alignment.Center
     ) {
         if (model == null) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
@@ -239,9 +239,9 @@ fun Button(
     val isEnabled = enabled && !loading
 
     val baseModifier = if (fullWidth) {
-        Modifier.then(minHeightModifier).fillMaxWidth().then(modifier)
+        modifier.then(minHeightModifier).fillMaxWidth()
     } else {
-        Modifier.then(minHeightModifier).then(modifier)
+        modifier.then(minHeightModifier)
     }
 
     // Use TextButton for Ghost and Link variants to match behavior and remove default elevation

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Card.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Card.kt
@@ -45,7 +45,7 @@ fun Card(
 ) {
     val styles = MaterialTheme.styles
     Box(
-        modifier = Modifier
+        modifier = modifier
             .drawShadows(radius, shadow)
             .clip(RoundedCornerShape(radius))
             .border(1.dp, styles.border, RoundedCornerShape(radius))
@@ -55,8 +55,7 @@ fun Card(
                 .background(
                     color = MaterialTheme.styles.card,
                     shape = RoundedCornerShape(radius)
-                )
-                .then(modifier), content = content
+                ), content = content
         )
     }
 }
@@ -74,10 +73,9 @@ fun CardHeader(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
-            .then(modifier),
+            .padding(16.dp),
         horizontalAlignment = horizontalAlignment,
         content = content
     )
@@ -147,10 +145,9 @@ fun CardContent(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .then(modifier),
+            .padding(horizontal = 16.dp),
         horizontalAlignment = horizontalAlignment,
         content = content
     )
@@ -171,10 +168,9 @@ fun CardFooter(
     content: @Composable RowScope.() -> Unit
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp)
-            .then(modifier),
+            .padding(16.dp),
         horizontalArrangement = horizontalArrangement,
         verticalAlignment = Alignment.CenterVertically,
         content = content

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
@@ -153,10 +153,9 @@ fun Drawer(
             properties = ModalBottomSheetProperties(shouldDismissOnBackPress),
         ) {
             Column(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp, vertical = 16.dp)
-                    .then(modifier)
             ) {
                 // Header (Title and Description)
                 Row(

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Empty.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Empty.kt
@@ -44,10 +44,9 @@ fun Empty(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(24.dp)
-            .then(modifier),
+            .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(24.dp),
         content = content
@@ -66,9 +65,8 @@ fun EmptyHeader(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
-            .widthIn(max = 384.dp)
-            .then(modifier),
+        modifier = modifier
+            .widthIn(max = 384.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),
         content = content
@@ -94,9 +92,8 @@ fun EmptyMedia(
     when (variant) {
         EmptyMediaVariant.Default -> {
             Box(
-                modifier = Modifier
-                    .padding(bottom = 8.dp)
-                    .then(modifier),
+                modifier = modifier
+                    .padding(bottom = 8.dp),
                 contentAlignment = Alignment.Center,
                 content = content
             )
@@ -104,14 +101,13 @@ fun EmptyMedia(
 
         EmptyMediaVariant.Icon -> {
             Box(
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = modifier.padding(bottom = 8.dp)
             ) {
                 Box(
                     modifier = Modifier
                         .size(40.dp)
                         .clip(RoundedCornerShape(MaterialTheme.radius.lg))
-                        .background(styles.muted)
-                        .then(modifier),
+                        .background(styles.muted),
                     contentAlignment = Alignment.Center
                 ) {
                     CompositionLocalProvider(LocalContentColor provides styles.foreground) {
@@ -187,10 +183,9 @@ fun EmptyContent(
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .widthIn(max = 384.dp)
-            .then(modifier),
+            .widthIn(max = 384.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         content = content

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
@@ -36,11 +36,10 @@ fun Slider(
     ComposeSlider(
         value = value,
         onValueChange = onValueChange,
-        // Defaults before the caller modifier so a caller can size the slider (narrower/taller).
-        modifier = Modifier
+        // Caller modifier starts the chain; defaults follow so a caller can override size.
+        modifier = modifier
             .fillMaxWidth()
-            .height(20.dp)
-            .then(modifier),
+            .height(20.dp),
         valueRange = valueRange,
         steps = steps,
         enabled = enabled,


### PR DESCRIPTION
Compose convention: the caller's modifier starts the ROOT chain. Violations where it's `.then(modifier)` after internal modifiers (caller padding/size behave unexpectedly or are silently ignored):

- Card.kt:47-61 — caller modifier applied to inner Column, not the bordered root Box; caller padding pads content instead of offsetting the card; clickable/weight/size land inside the border. CardHeader/Content/Footer too.
- Avatar.kt:59-63 — .then(modifier) after .size(size): caller Modifier.size() silently ignored.
- Empty.kt:47-50 — Modifier.fillMaxWidth().padding(24.dp).then(modifier); also EmptyMedia Icon variant puts modifier on the inner 40.dp box while Default puts it on the single box (105-121) — inconsistent between variants.
- Drawer.kt:133-137 — Modifier.fillMaxWidth().padding(...).then(modifier).
- Slider.kt:51-53 — modifier.fillMaxWidth().height(20.dp) appended AFTER caller modifier: cannot size the slider.
- Input.kt:132-138 — covered by the Input bug issue (root ignores modifier entirely).
- Button.kt:242 — minHeightModifier before modifier (benign, tidy anyway).