### PR TITLE
feat(a11y): accessibility pass across all components

### DIFF
--- a/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
@@ -7,8 +7,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -32,11 +30,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 
 /**
  * Data class to represent an individual item in the Accordion.
@@ -112,17 +112,18 @@ fun Accordion(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            val next = if (singleItemExpand) {
-                                if (isExpanded) emptySet() else setOf(item.id)
-                            } else {
-                                if (isExpanded) expandedItems - item.id else expandedItems + item.id
-                            }
-                            setOpen(next)
-                        }
+                        .komoClickable(
+                            role = Role.Button,
+                            stateDescription = if (isExpanded) "Expanded" else "Collapsed",
+                            onClick = {
+                                val next = if (singleItemExpand) {
+                                    if (isExpanded) emptySet() else setOf(item.id)
+                                } else {
+                                    if (isExpanded) expandedItems - item.id else expandedItems + item.id
+                                }
+                                setOpen(next)
+                            },
+                        )
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
@@ -140,7 +141,8 @@ fun Accordion(
 
                     Icon(
                         imageVector = chevron,
-                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        // Decorative: the header row already announces expanded/collapsed state.
+                        contentDescription = null,
                         tint = styles.foreground,
                         modifier = Modifier
                             .rotate(rotation)

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
@@ -15,6 +15,9 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -54,6 +57,7 @@ fun Alert(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .semantics { liveRegion = LiveRegionMode.Polite }
             .background(colors.backgroundColor, RoundedCornerShape(radius.md))
             .border(BorderStroke(1.dp, colors.borderColors), RoundedCornerShape(radius.md))
             .padding(16.dp)

--- a/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
@@ -15,6 +15,8 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -56,6 +58,7 @@ fun AlertDialog(
         Dialog(onDismissRequest = onDismissRequest, properties = properties) {
             Column(
                 modifier = modifier
+                    .semantics { paneTitle = "Alert dialog" }
                     .fillMaxWidth()
                     .background(styles.background, RoundedCornerShape(radius.lg))
                     .border(1.dp, styles.border, RoundedCornerShape(radius.lg))

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -45,6 +47,8 @@ enum class BadgeVariant {
  *   selected [variant] — set this when supplying a custom [backgroundColor] to keep text readable.
  * @param roundedSize The corner radius for the badge's shape. Defaults to a fully rounded shape
  *   (e.g., `Radius.full` which might correspond to `CircleShape` or a large Dp value).
+ * @param contentDescription Optional accessibility label. Set this for notification counts or the
+ *   content-less dot badge, which otherwise carry no meaning to screen readers.
  * @param content A composable lambda defining the content to be displayed inside the badge. When
  *   null the badge renders as a small dot. Typically this will be a
  *   [androidx.compose.material3.Text] composable.
@@ -56,6 +60,7 @@ fun Badge(
     backgroundColor: Color? = null,
     contentColor: Color? = null,
     roundedSize: Dp = MaterialTheme.radius.full,
+    contentDescription: String? = null,
     content: (@Composable () -> Unit)? = null
 ) {
     val styles = MaterialTheme.styles
@@ -85,6 +90,11 @@ fun Badge(
 
     Box(
         modifier = modifier
+            .then(
+                if (contentDescription != null)
+                    Modifier.semantics { this.contentDescription = contentDescription }
+                else Modifier
+            )
             .defaultMinSize(minWidth = size, minHeight = size)
             .background(containerColor, shape)
             .then(borderStroke?.let { Modifier.border(it, shape) }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -238,10 +239,12 @@ fun Button(
 
     val isEnabled = enabled && !loading
 
+    // minimumInteractiveComponentSize reserves a 48.dp touch target (visual stays small);
+    // must precede the defaultMinSize size modifier. Covers the sub-48 sizes (Xs 32, IconSm 28).
     val baseModifier = if (fullWidth) {
-        modifier.then(minHeightModifier).fillMaxWidth()
+        modifier.minimumInteractiveComponentSize().then(minHeightModifier).fillMaxWidth()
     } else {
-        modifier.then(minHeightModifier)
+        modifier.minimumInteractiveComponentSize().then(minHeightModifier)
     }
 
     // Use TextButton for Ghost and Link variants to match behavior and remove default elevation

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -241,10 +243,14 @@ fun Button(
 
     // minimumInteractiveComponentSize reserves a 48.dp touch target (visual stays small);
     // must precede the defaultMinSize size modifier. Covers the sub-48 sizes (Xs 32, IconSm 28).
+    // While loading the button is disabled, so announce "Loading" rather than only "disabled".
+    val loadingModifier = if (loading) {
+        Modifier.semantics { stateDescription = "Loading" }
+    } else Modifier
     val baseModifier = if (fullWidth) {
-        modifier.minimumInteractiveComponentSize().then(minHeightModifier).fillMaxWidth()
+        modifier.then(loadingModifier).minimumInteractiveComponentSize().then(minHeightModifier).fillMaxWidth()
     } else {
-        modifier.minimumInteractiveComponentSize().then(minHeightModifier)
+        modifier.then(loadingModifier).minimumInteractiveComponentSize().then(minHeightModifier)
     }
 
     // Use TextButton for Ghost and Link variants to match behavior and remove default elevation

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -49,6 +52,7 @@ import androidx.compose.ui.window.Dialog
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoSelectable
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
@@ -599,11 +603,13 @@ fun Calendar(
                                     .aspectRatio(1f)
                                     .clip(shape)
                                     .background(backgroundColor)
-                                    .clickable(
+                                    .komoSelectable(
+                                        selected = isSelected,
                                         enabled = isClickable,
+                                        role = Role.Button,
+                                        shape = shape,
                                         interactionSource = interactionSource,
-                                        indication = null
-                                    ) {
+                                        onClick = {
                                         when (selectionMode) {
                                             is CalendarSelectionMode.Single -> {
                                                 selectionMode.onDateSelected(date)
@@ -635,7 +641,9 @@ fun Calendar(
                                         if (!isCurrentMonth) {
                                             currentMonth = YearMonth.from(date)
                                         }
-                                    },
+                                        },
+                                    )
+                                    .semantics { contentDescription = date.toString() },
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import com.komoui.utils.komoSelectable
 import kotlinx.datetime.DayOfWeek
@@ -173,55 +174,6 @@ private fun Month.length(isLeapYear: Boolean): Int {
     }
 }
 
-// Helper function to get short weekday names
-private fun DayOfWeek.getShortName(): String {
-    return when (this) {
-        DayOfWeek.MONDAY -> "Mon"
-        DayOfWeek.TUESDAY -> "Tue"
-        DayOfWeek.WEDNESDAY -> "Wed"
-        DayOfWeek.THURSDAY -> "Thu"
-        DayOfWeek.FRIDAY -> "Fri"
-        DayOfWeek.SATURDAY -> "Sat"
-        DayOfWeek.SUNDAY -> "Sun"
-    }
-}
-
-// Helper function to get full month name
-private fun Month.getFullName(): String {
-    return when (this) {
-        Month.JANUARY -> "January"
-        Month.FEBRUARY -> "February"
-        Month.MARCH -> "March"
-        Month.APRIL -> "April"
-        Month.MAY -> "May"
-        Month.JUNE -> "June"
-        Month.JULY -> "July"
-        Month.AUGUST -> "August"
-        Month.SEPTEMBER -> "September"
-        Month.OCTOBER -> "October"
-        Month.NOVEMBER -> "November"
-        Month.DECEMBER -> "December"
-    }
-}
-
-// Helper function to get short month name
-private fun Month.getShortName(): String {
-    return when (this) {
-        Month.JANUARY -> "Jan"
-        Month.FEBRUARY -> "Feb"
-        Month.MARCH -> "Mar"
-        Month.APRIL -> "Apr"
-        Month.MAY -> "May"
-        Month.JUNE -> "Jun"
-        Month.JULY -> "Jul"
-        Month.AUGUST -> "Aug"
-        Month.SEPTEMBER -> "Sep"
-        Month.OCTOBER -> "Oct"
-        Month.NOVEMBER -> "Nov"
-        Month.DECEMBER -> "Dec"
-    }
-}
-
 /**
  * Converts a [DayOfWeek] to a Sunday-start index (Sunday=0, Monday=1, ..., Saturday=6).
  */
@@ -288,6 +240,7 @@ fun Calendar(
 ) {
     val themeColors = MaterialTheme.styles
     val radius = MaterialTheme.radius
+    val strings = MaterialTheme.komoStrings
     // Keyed on initialMonth so the view navigates when the caller changes it after first composition.
     var currentMonth by remember(initialMonth) { mutableStateOf(initialMonth) }
     val today = remember {
@@ -318,7 +271,7 @@ fun Calendar(
     }
 
     // Weekday names (e.g., "Sun", "Mon")
-    val weekdays = remember {
+    val weekdays = remember(strings) {
         listOf(
             DayOfWeek.SUNDAY,
             DayOfWeek.MONDAY,
@@ -327,7 +280,7 @@ fun Calendar(
             DayOfWeek.THURSDAY,
             DayOfWeek.FRIDAY,
             DayOfWeek.SATURDAY
-        ).map { it.getShortName() }
+        ).map { strings.weekdayNamesShort[it.ordinal] }
     }
 
     // Pre-compute text styles used in the day grid
@@ -375,7 +328,7 @@ fun Calendar(
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
-                                text = currentMonth.month.getShortName(),
+                                text = strings.monthNamesShort[currentMonth.month.ordinal],
                                 style = TextStyle(
                                     fontSize = 16.sp,
                                     fontWeight = FontWeight.Medium
@@ -742,7 +695,7 @@ private fun MonthPickerDialog(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = month.getFullName(),
+                            text = MaterialTheme.komoStrings.monthNamesFull[month.ordinal],
                             style = TextStyle(
                                 color = textColor,
                                 fontSize = 16.sp,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -25,6 +24,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoToggleable
 
 /**
  * A Jetpack Compose Checkbox component for KomoUI.
@@ -92,13 +92,13 @@ fun Checkbox(
             .clip(RoundedCornerShape(radius.sm))
             .background(backgroundColor)
             .border(1.dp, currentBorderColor, RoundedCornerShape(radius.sm))
-            .toggleable(
+            .komoToggleable(
                 value = checked,
                 onValueChange = { newChecked -> onCheckedChange?.invoke(newChecked) },
                 enabled = enabled,
                 role = Role.Checkbox,
+                shape = RoundedCornerShape(radius.sm),
                 interactionSource = interactionSource,
-                indication = null
             ),
         contentAlignment = Alignment.Center
     ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -88,10 +89,6 @@ fun Checkbox(
 
     Box(
         modifier = modifier
-            .size(24.dp)
-            .clip(RoundedCornerShape(radius.sm))
-            .background(backgroundColor)
-            .border(1.dp, currentBorderColor, RoundedCornerShape(radius.sm))
             .komoToggleable(
                 value = checked,
                 onValueChange = { newChecked -> onCheckedChange?.invoke(newChecked) },
@@ -99,7 +96,13 @@ fun Checkbox(
                 role = Role.Checkbox,
                 shape = RoundedCornerShape(radius.sm),
                 interactionSource = interactionSource,
-            ),
+            )
+            // Expands the touch target to 48.dp; the 24.dp visual stays (must follow min-size).
+            .minimumInteractiveComponentSize()
+            .size(24.dp)
+            .clip(RoundedCornerShape(radius.sm))
+            .background(backgroundColor)
+            .border(1.dp, currentBorderColor, RoundedCornerShape(radius.sm)),
         contentAlignment = Alignment.Center
     ) {
         if (checked) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Collapsible.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Collapsible.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -17,6 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import com.komoui.utils.komoClickable
 
 /**
  * Scope exposing the [CollapsibleTrigger] and [CollapsibleContent] slots inside a
@@ -43,15 +43,13 @@ class CollapsibleScope internal constructor(
         verticalAlignment: Alignment.Vertical = Alignment.Top,
         content: @Composable RowScope.() -> Unit
     ) {
-        val interactionSource = remember { MutableInteractionSource() }
         Row(
-            modifier = modifier.clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                enabled = enabled
-            ) {
-                onOpenChange(!open)
-            },
+            modifier = modifier.komoClickable(
+                onClick = { onOpenChange(!open) },
+                enabled = enabled,
+                role = Role.Button,
+                stateDescription = if (open) "Expanded" else "Collapsed",
+            ),
             horizontalArrangement = horizontalArrangement,
             verticalAlignment = verticalAlignment,
             content = content

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import kotlin.math.roundToInt
@@ -216,7 +217,7 @@ fun ComboBox(
                             value = searchText,
                             onValueChange = { searchText = it },
                             variant = InputVariant.Underlined,
-                            placeholder = "Search options...",
+                            placeholder = MaterialTheme.komoStrings.searchPlaceholder,
                             leadingIcon = { Icon(Icons.Default.Search, contentDescription = "search") },
                             singleLine = true,
                             focusRequester = searchFocusRequester,
@@ -224,7 +225,7 @@ fun ComboBox(
 
                         if (filteredOptions.isEmpty()) {
                             Text(
-                                text = "No results found.",
+                                text = MaterialTheme.komoStrings.noResultsFound,
                                 color = styles.mutedForeground,
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -53,6 +54,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 import kotlin.math.roundToInt
 
 /**
@@ -141,19 +143,22 @@ fun ComboBox(
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .then(
                     if (enabled) {
-                        Modifier.clickable(
-                            interactionSource = interactionSource,
-                            indication = null
-                        ) {
-                            expanded = !expanded
-                            if (expanded) {
-                                searchText = ""
-                            } else {
-                                if (selectedOption == null && searchText.isNotBlank()) {
+                        Modifier.komoClickable(
+                            onClick = {
+                                expanded = !expanded
+                                if (expanded) {
                                     searchText = ""
+                                } else {
+                                    if (selectedOption == null && searchText.isNotBlank()) {
+                                        searchText = ""
+                                    }
                                 }
-                            }
-                        }
+                            },
+                            role = Role.DropdownList,
+                            shape = RoundedCornerShape(radius.md),
+                            stateDescription = if (expanded) "Expanded" else "Collapsed",
+                            interactionSource = interactionSource,
+                        )
                     } else {
                         Modifier
                     }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -31,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -38,6 +38,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 import kotlinx.datetime.LocalDate
 import kotlin.math.roundToInt
 
@@ -156,12 +157,13 @@ fun DatePicker(
                 }
                 .clip(RoundedCornerShape(radius.md))
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
-                .clickable(
+                .komoClickable(
+                    onClick = { showCalendarPopup = !showCalendarPopup },
+                    role = Role.DropdownList,
+                    shape = RoundedCornerShape(radius.md),
+                    stateDescription = if (showCalendarPopup) "Expanded" else "Collapsed",
                     interactionSource = interactionSource,
-                    indication = null
-                ) {
-                    showCalendarPopup = !showCalendarPopup
-                }
+                )
                 .padding(horizontal = 12.dp),
             contentAlignment = Alignment.CenterStart
         ) {
@@ -278,12 +280,13 @@ fun DateRangePicker(
                 }
                 .clip(RoundedCornerShape(radius.md))
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
-                .clickable(
+                .komoClickable(
+                    onClick = { showCalendarPopup = !showCalendarPopup },
+                    role = Role.DropdownList,
+                    shape = RoundedCornerShape(radius.md),
+                    stateDescription = if (showCalendarPopup) "Expanded" else "Collapsed",
                     interactionSource = interactionSource,
-                    indication = null
-                ) {
-                    showCalendarPopup = !showCalendarPopup
-                }
+                )
                 .padding(horizontal = 12.dp),
             contentAlignment = Alignment.CenterStart
         ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import androidx.compose.ui.window.Dialog as ComposeDialog
 import androidx.compose.ui.window.DialogProperties
@@ -91,7 +92,7 @@ fun Dialog(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Close,
-                                contentDescription = "Close",
+                                contentDescription = MaterialTheme.komoStrings.closeDialog,
                                 tint = styles.mutedForeground
                             )
                         }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -60,6 +62,7 @@ fun Dialog(
         ComposeDialog(onDismissRequest = onDismissRequest, properties = properties) {
             Column(
                 modifier = modifier
+                    .semantics { paneTitle = "Dialog" }
                     .fillMaxWidth()
                     .background(styles.background, RoundedCornerShape(radius.lg))
                     .border(1.dp, styles.border, RoundedCornerShape(radius.lg))

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 
 /**
@@ -193,7 +194,7 @@ fun Drawer(
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Close,
-                                    contentDescription = "Close",
+                                    contentDescription = MaterialTheme.komoStrings.close,
                                     tint = styles.mutedForeground
                                 )
                             }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
@@ -146,6 +148,8 @@ fun Input(
             modifier = Modifier
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = 44.dp)
+                // Expose the error state to screen readers (visual-only border color otherwise).
+                .then(if (isError) Modifier.semantics { error("Invalid input") } else Modifier)
                 .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                 .then(borderStyle),
             enabled = enabled,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -142,6 +143,7 @@ fun InputOTP(
             if (filtered != sanitized) onValueChange(filtered)
         },
         modifier = modifier
+            .minimumInteractiveComponentSize()
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
         enabled = enabled,
         readOnly = readOnly,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -144,6 +147,12 @@ fun InputOTP(
         },
         modifier = modifier
             .minimumInteractiveComponentSize()
+            // The visible slots are plain Boxes and the real field is size(0).alpha(0); without
+            // this the component is invisible to screen readers. Describe progress + error state.
+            .semantics {
+                contentDescription = "Verification code, ${sanitized.length} of $length digits entered"
+                if (isError) error("Invalid verification code")
+            }
             .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
         enabled = enabled,
         readOnly = readOnly,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Progress.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Progress.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -44,6 +45,7 @@ fun Progress(
 
     Box(
         modifier = modifier
+            .progressSemantics(clampedProgress)
             .fillMaxWidth()
             .height(height)
             .clip(RoundedCornerShape(radius.full))

--- a/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
@@ -1,12 +1,10 @@
 package com.komoui.components
 
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -14,7 +12,6 @@ import androidx.compose.material3.RadioButtonColors
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -23,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.styles
+import com.komoui.utils.komoSelectable
 
 /**
  * Scope exposed to a [RadioGroup]'s content. Carries the group's current selection
@@ -102,13 +100,11 @@ fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
 
     Row(
         modifier = modifier
-            .selectable(
+            .komoSelectable(
                 selected = isSelected,
                 onClick = { onValueChange(value) },
                 enabled = enabled,
                 role = Role.RadioButton,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
             )
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.RadioButtonColors
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
@@ -106,6 +107,7 @@ fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
                 enabled = enabled,
                 role = Role.RadioButton,
             )
+            .minimumInteractiveComponentSize()
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +55,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 import kotlin.math.roundToInt
 
 /**
@@ -125,13 +127,14 @@ fun <T> Select(
                 }
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .clip(RoundedCornerShape(radius.md))
-                .clickable(
+                .komoClickable(
+                    onClick = { expanded = !expanded },
+                    enabled = enabled,
+                    role = Role.DropdownList,
+                    shape = RoundedCornerShape(radius.md),
+                    stateDescription = if (expanded) "Expanded" else "Collapsed",
                     interactionSource = interactionSource,
-                    indication = null,
-                    enabled = enabled
-                ) {
-                    expanded = !expanded
-                }
+                )
                 .padding(horizontal = 12.dp),
             contentAlignment = Alignment.CenterStart
         ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Spinner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Spinner.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -58,11 +59,14 @@ fun Spinner(
     color: Color = MaterialTheme.styles.primary,
     strokeWidth: Dp = 3.dp
 ) {
+    // Indeterminate progress semantics so the spinner is perceivable to TalkBack/VoiceOver
+    // instead of being a purely decorative animation.
+    val semanticsModifier = modifier.progressSemantics()
     when (variant) {
-        SpinnerVariant.Circular -> CircularSpinner(modifier, size, color, strokeWidth)
-        SpinnerVariant.Bounce -> BounceSpinner(modifier, size, color)
-        SpinnerVariant.Moon -> MoonSpinner(modifier, size, color, strokeWidth)
-        SpinnerVariant.Pulse -> PulseSpinner(modifier, size, color)
+        SpinnerVariant.Circular -> CircularSpinner(semanticsModifier, size, color, strokeWidth)
+        SpinnerVariant.Bounce -> BounceSpinner(semanticsModifier, size, color)
+        SpinnerVariant.Moon -> MoonSpinner(semanticsModifier, size, color, strokeWidth)
+        SpinnerVariant.Pulse -> PulseSpinner(semanticsModifier, size, color)
     }
 }
 

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -23,6 +22,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.komoui.themes.styles
+import com.komoui.utils.komoToggleable
 
 /**
  * A Jetpack Compose Switch component for KomoUI.
@@ -82,13 +82,13 @@ fun Switch(
             // drop our own click handling and toggleable semantics entirely.
             .then(
                 if (onCheckedChange != null) {
-                    Modifier.toggleable(
+                    Modifier.komoToggleable(
                         value = checked,
                         onValueChange = onCheckedChange,
                         enabled = enabled,
                         role = Role.Switch,
+                        shape = CircleShape,
                         interactionSource = interactionSource,
-                        indication = null
                     )
                 } else {
                     Modifier

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -76,24 +77,27 @@ fun Switch(
 
     Box(
         modifier = modifier
-            .size(width = switchWidth, height = switchHeight)
-            .border(1.dp, borderColor.copy(alpha = if (enabled) 1f else disabledAlpha), CircleShape)
             // A null callback means the parent owns interaction (e.g. a clickable labeled row):
-            // drop our own click handling and toggleable semantics entirely.
+            // drop our own click handling and toggleable semantics entirely. When interactive,
+            // reserve a 48.dp touch target (visual stays 40x18, drawn below by size + drawBehind).
             .then(
                 if (onCheckedChange != null) {
-                    Modifier.komoToggleable(
-                        value = checked,
-                        onValueChange = onCheckedChange,
-                        enabled = enabled,
-                        role = Role.Switch,
-                        shape = CircleShape,
-                        interactionSource = interactionSource,
-                    )
+                    Modifier
+                        .komoToggleable(
+                            value = checked,
+                            onValueChange = onCheckedChange,
+                            enabled = enabled,
+                            role = Role.Switch,
+                            shape = CircleShape,
+                            interactionSource = interactionSource,
+                        )
+                        .minimumInteractiveComponentSize()
                 } else {
                     Modifier
                 }
             )
+            .size(width = switchWidth, height = switchHeight)
+            .border(1.dp, borderColor.copy(alpha = if (enabled) 1f else disabledAlpha), CircleShape)
             .drawBehind {
                 val trackCornerRadius = CornerRadius(switchHeight.toPx() / 2f)
                 val thumbRadius = thumbSize.toPx() / 2f

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.semantics.Role
 import com.komoui.themes.radius
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 
@@ -297,7 +298,7 @@ fun PaginationScope.DefaultPagination() {
             size = ButtonSize.Sm,
             enabled = canPrev
         ) {
-            Text("Previous")
+            Text(MaterialTheme.komoStrings.previous)
         }
         Spacer(modifier = Modifier.width(8.dp))
         Button(
@@ -306,7 +307,7 @@ fun PaginationScope.DefaultPagination() {
             size = ButtonSize.Sm,
             enabled = canNext
         ) {
-            Text("Next")
+            Text(MaterialTheme.komoStrings.next)
         }
     }
 }
@@ -478,7 +479,7 @@ fun <T> DataTable(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
-                                    text = "No results.",
+                                    text = MaterialTheme.komoStrings.noResults,
                                     color = styles.mutedForeground,
                                     style = MaterialTheme.typography.bodyMedium
                                 )
@@ -538,13 +539,16 @@ fun <T> DataTable(
         ) {
             if (enableSelection) {
                 Text(
-                    text = "${selectedKeySet.size} of ${sorted.size} row(s) selected.",
+                    text = MaterialTheme.komoStrings.rowsSelected(selectedKeySet.size, sorted.size),
                     color = styles.mutedForeground,
                     style = MaterialTheme.typography.bodySmall
                 )
             }
             Text(
-                text = "Page ${paginationScope.page + 1} of ${paginationScope.pageCount}",
+                text = MaterialTheme.komoStrings.pageIndicator(
+                    paginationScope.page + 1,
+                    paginationScope.pageCount,
+                ),
                 color = styles.mutedForeground,
                 style = MaterialTheme.typography.bodySmall
             )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
@@ -3,9 +3,7 @@ package com.komoui.components
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,8 +40,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.Role
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 
 /**
  * Root Table primitive. Wraps content in a horizontally scrollable container with a rounded
@@ -139,10 +139,10 @@ fun TableRow(
     val styles = MaterialTheme.styles
     val background = if (selected) styles.muted else styles.card
     val clickModifier = if (onClick != null) {
-        Modifier.clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null,
-            onClick = onClick
+        Modifier.komoClickable(
+            onClick = onClick,
+            role = Role.Button,
+            stateDescription = if (selected) "Selected" else null,
         )
     } else Modifier
     Row(
@@ -564,10 +564,15 @@ private fun SortableHeader(
     val clickable = column.sortable && column.comparator != null
 
     val rowModifier = if (clickable) {
-        Modifier.clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null,
-            onClick = onClick
+        Modifier.komoClickable(
+            onClick = onClick,
+            role = Role.Button,
+            stateDescription = when {
+                !isActive -> "Not sorted"
+                sort.direction == SortDirection.ASC -> "Sorted ascending"
+                sort.direction == SortDirection.DESC -> "Sorted descending"
+                else -> "Not sorted"
+            },
         )
     } else Modifier
 

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -129,6 +130,7 @@ fun TabsTrigger(
                 role = Role.Tab,
                 shape = RoundedCornerShape(radius.sm),
             )
+            .minimumInteractiveComponentSize()
             .padding(horizontal = 12.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
@@ -3,7 +3,6 @@ package com.komoui.components
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,11 +17,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoSelectable
 
 /**
  * @param selectedTabIndex The index of the currently selected tab.
@@ -122,7 +123,12 @@ fun TabsTrigger(
         modifier = modifier
             .clip(RoundedCornerShape(radius.sm))
             .background(backgroundColor)
-            .clickable { onClick() }
+            .komoSelectable(
+                selected = isSelected,
+                onClick = onClick,
+                role = Role.Tab,
+                shape = RoundedCornerShape(radius.sm),
+            )
             .padding(horizontal = 12.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/AreaChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/AreaChart.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -109,7 +111,14 @@ fun AreaChart(
     val effectiveShowTooltip = showTooltip && !scrollable
     val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription =
+                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
+            }
+    ) {
         Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
             if (axisOptions.showY) {
                 Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/BarChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/BarChart.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
@@ -109,7 +111,14 @@ fun BarChart(
     val effectiveShowTooltip = showTooltip && !scrollable
     val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription =
+                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
+            }
+    ) {
         Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
             // Pinned y-axis canvas
             if (axisOptions.showY) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
@@ -412,6 +412,22 @@ internal fun DrawScope.drawScrubIndicator(
 }
 
 /**
+ * Screen-reader summary for a chart (series labels + points-per-series). The chart itself is a
+ * silent Canvas; apply this via `semantics { contentDescription = ... }` on the chart root.
+ * See issue shadcn-ui-kmp-mjl.3.
+ */
+internal fun chartSemanticsLabel(seriesLabels: List<String>, pointCount: Int): String =
+    buildString {
+        append("Chart, ")
+        append(seriesLabels.size)
+        append(" series (")
+        append(seriesLabels.joinToString(", "))
+        append("), ")
+        append(pointCount)
+        append(" data points each")
+    }
+
+/**
  * Small flow-row of color-dot + label chips, rendered below the chart when enabled.
  */
 @Composable

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/LineChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/LineChart.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -107,7 +109,14 @@ fun LineChart(
     val effectiveShowTooltip = showTooltip && !scrollable
     val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription =
+                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
+            }
+    ) {
         Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
             if (axisOptions.showY) {
                 Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
@@ -37,6 +37,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
@@ -49,6 +51,7 @@ import com.komoui.components.ButtonVariant
 import com.komoui.components.Input
 import com.komoui.components.InputVariant
 import com.komoui.themes.drawShadows
+import com.komoui.themes.komoStrings
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -337,15 +340,18 @@ fun SidebarTrigger(
     content: @Composable () -> Unit = {
         Icon(
             Icons.Default.Menu,
-            contentDescription = "Toggle Sidebar",
+            contentDescription = MaterialTheme.komoStrings.toggleSidebar,
             tint = MaterialTheme.styles.sidebarForeground,
         )
     },
 ) {
     val state = LocalSidebarState.current
+    val strings = MaterialTheme.komoStrings
     Button(
         onClick = { state.toggleSidebar() },
-        modifier = modifier,
+        modifier = modifier.semantics {
+            stateDescription = if (state.isOpen) strings.expanded else strings.collapsed
+        },
         size = ButtonSize.Icon,
         variant = ButtonVariant.Ghost,
     ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
@@ -223,14 +223,23 @@ private fun BoxScope.RailOverlay(side: SidebarSide) {
     val state = LocalSidebarState.current
     val styles = MaterialTheme.styles
 
+    // ponytail: 20.dp hit strip, not the full 48.dp — a 48-wide rail would overlap sidebar
+    // content along the whole edge. Widen further only if touch misses are reported.
     Box(
         modifier = Modifier
             .fillMaxHeight()
-            .width(4.dp)
+            .width(20.dp)
             .align(if (side == SidebarSide.Left) Alignment.CenterEnd else Alignment.CenterStart)
-            .background(styles.sidebarBorder)
             .clickable { state.toggleSidebar() },
-    )
+        contentAlignment = if (side == SidebarSide.Left) Alignment.CenterEnd else Alignment.CenterStart,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(4.dp)
+                .background(styles.sidebarBorder),
+        )
+    }
 }
 
 /**

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarGroup.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarGroup.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -97,9 +96,10 @@ fun SidebarGroupAction(
             .padding(horizontal = 4.dp),
         contentAlignment = Alignment.CenterEnd,
     ) {
+        // No hard .size(20.dp): it clamped the button below the 48.dp touch target Button now
+        // reserves. IconSm keeps the compact visual.
         Button(
             onClick = onClick,
-            modifier = Modifier.size(20.dp),
             size = ButtonSize.IconSm,
             variant = ButtonVariant.Ghost,
             content = { content() },

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -257,13 +258,14 @@ fun SidebarMenuAction(
     Box(
         modifier = modifier
             .padding(end = 4.dp)
-            .size(20.dp)
-            .clip(RoundedCornerShape(MaterialTheme.radius.sm))
             .komoClickable(
                 onClick = onClick,
                 role = Role.Button,
                 shape = RoundedCornerShape(MaterialTheme.radius.sm),
-            ),
+            )
+            .minimumInteractiveComponentSize()
+            .size(20.dp)
+            .clip(RoundedCornerShape(MaterialTheme.radius.sm)),
         contentAlignment = Alignment.Center,
         content = { content() },
     )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
@@ -2,7 +2,6 @@ package com.komoui.components.sidebar
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -33,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.sp
 import com.komoui.components.Skeleton
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 
 // ---------------------------------------------------------------------------
 // Variant and size enums (mirror React CVA variants).
@@ -149,7 +150,12 @@ fun SidebarMenuButton(
                     .clip(shape)
                     .background(outlineBackground)
                     .then(borderModifier)
-                    .clickable(onClick = clickHandler),
+                    .komoClickable(
+                        onClick = clickHandler,
+                        role = Role.Button,
+                        shape = shape,
+                        stateDescription = if (isActive) "Selected" else null,
+                    ),
                 contentAlignment = Alignment.Center,
             ) {
                 icon?.invoke()
@@ -162,7 +168,12 @@ fun SidebarMenuButton(
                     .clip(shape)
                     .background(outlineBackground)
                     .then(borderModifier)
-                    .clickable(onClick = clickHandler)
+                    .komoClickable(
+                        onClick = clickHandler,
+                        role = Role.Button,
+                        shape = shape,
+                        stateDescription = if (isActive) "Selected" else null,
+                    )
                     .padding(horizontal = 8.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -248,7 +259,11 @@ fun SidebarMenuAction(
             .padding(end = 4.dp)
             .size(20.dp)
             .clip(RoundedCornerShape(MaterialTheme.radius.sm))
-            .clickable(onClick = onClick),
+            .komoClickable(
+                onClick = onClick,
+                role = Role.Button,
+                shape = RoundedCornerShape(MaterialTheme.radius.sm),
+            ),
         contentAlignment = Alignment.Center,
         content = { content() },
     )
@@ -378,7 +393,12 @@ fun SidebarMenuSubButton(
             .heightIn(min = height)
             .clip(shape)
             .background(backgroundColor)
-            .clickable(onClick = clickHandler)
+            .komoClickable(
+                onClick = clickHandler,
+                role = Role.Button,
+                shape = shape,
+                stateDescription = if (isActive) "Selected" else null,
+            )
             .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -70,6 +71,7 @@ fun Sonner(
                                 role = Role.Button,
                                 shape = RoundedCornerShape(radius.sm),
                             )
+                            .minimumInteractiveComponentSize()
                     ) {
                         Text(actionLabel, color = styles.destructiveForeground)
                     }
@@ -95,6 +97,7 @@ fun Sonner(
                                 role = Role.Button,
                                 shape = RoundedCornerShape(radius.sm),
                             )
+                            .minimumInteractiveComponentSize()
                     ) {
                         Icon(
                             Icons.Default.Close,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -1,7 +1,6 @@
 package com.komoui.components.sonner
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +14,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -26,6 +26,7 @@ import com.komoui.themes.radius
 import androidx.compose.ui.graphics.Color
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.styles
+import com.komoui.utils.komoClickable
 
 /**
  * A styled snackbar component inspired by the Sonner toast library.
@@ -64,7 +65,11 @@ fun Sonner(
                     Box(
                         modifier = Modifier
                             .padding(end = 8.dp)
-                            .clickable(onClick = onActionClick)
+                            .komoClickable(
+                                onClick = onActionClick,
+                                role = Role.Button,
+                                shape = RoundedCornerShape(radius.sm),
+                            )
                     ) {
                         Text(actionLabel, color = styles.destructiveForeground)
                     }
@@ -85,7 +90,11 @@ fun Sonner(
                     Box(
                         modifier = Modifier
                             .padding(end = 16.dp)
-                            .clickable(onClick = onDismiss)
+                            .komoClickable(
+                                onClick = onDismiss,
+                                role = Role.Button,
+                                shape = RoundedCornerShape(radius.sm),
+                            )
                     ) {
                         Icon(
                             Icons.Default.Close,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -29,6 +29,7 @@ import com.komoui.components.ButtonVariant
 import com.komoui.themes.radius
 import androidx.compose.ui.graphics.Color
 import com.komoui.themes.KomoStyles
+import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 
@@ -105,7 +106,7 @@ fun Sonner(
                     ) {
                         Icon(
                             Icons.Default.Close,
-                            contentDescription = "close",
+                            contentDescription = MaterialTheme.komoStrings.close,
                             tint = styles.destructiveForeground
                         )
                     }
@@ -116,7 +117,7 @@ fun Sonner(
                         size = ButtonSize.Icon,
                         modifier = Modifier.padding(end = 8.dp)
                     ) {
-                        Icon(Icons.Default.Close, contentDescription = "close")
+                        Icon(Icons.Default.Close, contentDescription = MaterialTheme.komoStrings.close)
                     }
                 }
             }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -15,7 +15,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -58,6 +61,7 @@ fun Sonner(
     val (containerColor, contentColor, actionContentColor, border) = resolveSonnerColors(variant, styles)
     Snackbar(
         modifier = modifier
+            .semantics { liveRegion = LiveRegionMode.Polite }
             .padding(16.dp)
             .border(1.dp, border, RoundedCornerShape(radius.lg)),
         action = if (actionLabel != null && onActionClick != null) {

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/KomoStrings.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/KomoStrings.kt
@@ -1,0 +1,51 @@
+package com.komoui.themes
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Localizable UI strings for KomoUI components (labels, accessibility descriptions, calendar
+ * names). Override via [KomoTheme]'s `strings` parameter — English defaults keep existing
+ * callers working unchanged. Read within components via `MaterialTheme.komoStrings`.
+ *
+ * Month/weekday name lists are indexed by the corresponding `ordinal`: months JANUARY(0)..
+ * DECEMBER(11), weekdays MONDAY(0)..SUNDAY(6).
+ */
+data class KomoStrings(
+    val closeDialog: String = "Close dialog",
+    val close: String = "Close",
+    val toggleSidebar: String = "Toggle Sidebar",
+    val expanded: String = "Expanded",
+    val collapsed: String = "Collapsed",
+    val previous: String = "Previous",
+    val next: String = "Next",
+    val noResults: String = "No results.",
+    val noResultsFound: String = "No results found.",
+    val searchPlaceholder: String = "Search options...",
+    val rowsSelected: (selected: Int, total: Int) -> String = { selected, total ->
+        "$selected of $total row(s) selected."
+    },
+    val pageIndicator: (page: Int, pageCount: Int) -> String = { page, pageCount ->
+        "Page $page of $pageCount"
+    },
+    val monthNamesFull: List<String> = listOf(
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    ),
+    val monthNamesShort: List<String> = listOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ),
+    val weekdayNamesShort: List<String> = listOf(
+        "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+    ),
+)
+
+internal val LocalKomoStrings = staticCompositionLocalOf { KomoStrings() }
+
+val MaterialTheme.komoStrings: KomoStrings
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalKomoStrings.current

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/KomoTheme.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/KomoTheme.kt
@@ -30,6 +30,7 @@ internal val LocalKomoDarkMode = staticCompositionLocalOf { false }
  * @param materialLightColors The Material 3 [ColorScheme] to be used for the light theme. Defaults to [lightColorScheme].
  * @param materialDarkColors The Material 3 [ColorScheme] to be used for the dark theme. Defaults to [darkColorScheme].
  * @param komoRadius The [KomoRadius] to be used. Defaults to [Radius].
+ * @param strings The [KomoStrings] (localizable labels/descriptions) to be used. Defaults to English.
  * @param typography The Material 3 [Typography] to be used. Defaults to [DefaultTypography].
  * @param content The composable content to be themed.
  */
@@ -41,6 +42,7 @@ fun KomoTheme(
     materialLightColors: ColorScheme = lightColorScheme(),
     materialDarkColors: ColorScheme = darkColorScheme(),
     komoRadius: KomoRadius = Radius,
+    strings: KomoStrings = KomoStrings(),
     typography: Typography? = null,
     content: @Composable () -> Unit,
 ) {
@@ -49,6 +51,7 @@ fun KomoTheme(
     CompositionLocalProvider(
         LocalKomoStyles provides colors,
         LocalKomoRadius provides komoRadius,
+        LocalKomoStrings provides strings,
         LocalKomoDarkMode provides isDarkTheme
     ) {
         MaterialTheme(

--- a/komoui/src/commonMain/kotlin/com/komoui/utils/KomoInteraction.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/utils/KomoInteraction.kt
@@ -1,0 +1,119 @@
+package com.komoui.utils
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import com.komoui.themes.styles
+
+// Shared clickable helpers for KomoUI's hand-rolled interactive components.
+// Every one provides three things the raw foundation modifiers left out across the library:
+//   1. ripple press/hover indication (was `indication = null` everywhere),
+//   2. a visible keyboard-focus ring (styles.ring), which nothing had, and
+//   3. a role + optional stateDescription so screen readers announce the control.
+// See feedback.md §2.1 / issue shadcn-ui-kmp-mjl.1.
+
+/**
+ * Draws a 2.dp focus ring in [color] following [shape] when [focused]. Inset stroke, so it
+ * never changes layout size. Apply as the outermost visual so it paints over any background.
+ */
+internal fun Modifier.komoFocusRing(focused: Boolean, color: Color, shape: Shape): Modifier =
+    if (focused) this.border(2.dp, color, shape) else this
+
+private fun Modifier.komoStateDescription(desc: String?): Modifier =
+    if (desc != null) this.semantics { stateDescription = desc } else this
+
+/**
+ * Clickable with ripple, keyboard-focus ring, and a semantics [role]/[stateDescription].
+ *
+ * @param shape Shape the focus ring follows — pass the same shape the element is clipped to.
+ */
+fun Modifier.komoClickable(
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    role: Role? = Role.Button,
+    shape: Shape = RectangleShape,
+    stateDescription: String? = null,
+    onClickLabel: String? = null,
+    interactionSource: MutableInteractionSource? = null,
+): Modifier = composed {
+    val source = interactionSource ?: remember { MutableInteractionSource() }
+    val focused by source.collectIsFocusedAsState()
+    komoFocusRing(focused, MaterialTheme.styles.ring, shape)
+        .clickable(
+            interactionSource = source,
+            indication = ripple(),
+            enabled = enabled,
+            role = role,
+            onClickLabel = onClickLabel,
+            onClick = onClick,
+        )
+        .komoStateDescription(stateDescription)
+}
+
+/**
+ * Toggleable (checkbox/switch) with ripple, keyboard-focus ring, and role/state semantics.
+ */
+fun Modifier.komoToggleable(
+    value: Boolean,
+    onValueChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
+    role: Role = Role.Checkbox,
+    shape: Shape = RectangleShape,
+    stateDescription: String? = null,
+    interactionSource: MutableInteractionSource? = null,
+): Modifier = composed {
+    val source = interactionSource ?: remember { MutableInteractionSource() }
+    val focused by source.collectIsFocusedAsState()
+    komoFocusRing(focused, MaterialTheme.styles.ring, shape)
+        .toggleable(
+            value = value,
+            interactionSource = source,
+            indication = ripple(),
+            enabled = enabled,
+            role = role,
+            onValueChange = onValueChange,
+        )
+        .komoStateDescription(stateDescription)
+}
+
+/**
+ * Selectable (tab/day/radio) with ripple, keyboard-focus ring, and role/state semantics.
+ */
+fun Modifier.komoSelectable(
+    selected: Boolean,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    role: Role = Role.Tab,
+    shape: Shape = RectangleShape,
+    stateDescription: String? = null,
+    interactionSource: MutableInteractionSource? = null,
+): Modifier = composed {
+    val source = interactionSource ?: remember { MutableInteractionSource() }
+    val focused by source.collectIsFocusedAsState()
+    komoFocusRing(focused, MaterialTheme.styles.ring, shape)
+        .selectable(
+            selected = selected,
+            interactionSource = source,
+            indication = ripple(),
+            enabled = enabled,
+            role = role,
+            onClick = onClick,
+        )
+        .komoStateDescription(stateDescription)
+}


### PR DESCRIPTION
Brings KomoUI components up to baseline accessibility — screen-reader semantics, keyboard focus, and touch-target sizing — plus localizable strings. No breaking changes; every new param is optional with an English/default fallback.

What changed

1. Shared interaction helper (utils/KomoInteraction.kt)
Modifier.komoClickable / komoToggleable / komoSelectable — one place providing ripple, a focus ring (2 dp border in styles.ring), and correct Role/stateDescription semantics. Adopted across every hand-rolled .clickable {}: Checkbox, Switch, RadioButton, Tabs, Accordion, Collapsible, Select/Combobox/DatePicker triggers, Calendar days, Table rows/header, Sidebar, Sonner.

2. Touch targets
minimumInteractiveComponentSize() (48 dp) on interactive components, with the correct modifier ordering (interaction → min-size → visual size) so the hit area actually expands.

3. Status & non-interactive semantics
- Alert, Sonner → liveRegion = Polite (announced on appearance)
- Spinner → progressSemantics() (indeterminate)
- Progress → progressSemantics(value)
- Bar/Line/AreaChart → merged contentDescription summarizing series + point count
- Badge → new optional contentDescription param (for counts / the content-less dot)
- Dialog/AlertDialog → paneTitle; Input/InputOTP → error() state
- Button → "Loading" state description when loading

4. Localizable strings (themes/KomoStrings.kt)
KomoTheme(strings = KomoStrings(...)) replaces hardcoded English labels (dialog close, sidebar toggle, "No results", search placeholder, month/weekday names, row/page indicators). English defaults keep existing callers unchanged.

Deliberate scope limits

- Sidebar rail → 20 dp hit strip, not 48 dp (a full target would overlap sidebar content). ponytail: noted.
- Calendar day cells → left on weight/aspectRatio (already ≥48 dp at normal widths; forcing 48 overflows the 7-column grid).
- A few stateDescription literals ("Expanded"/"Selected") aren't yet routed through KomoStrings.