### PR TITLE
perf: enhancement component code structure

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/App.kt
@@ -5,24 +5,21 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
+
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.navigation.compose.rememberNavController
-import com.komoui.components.sonner.ObserveAsEvent
+import com.komoui.components.sonner.rememberSonnerHostState
 import com.komoui.components.sonner.SonnerHost
 import com.komoui.components.sonner.SonnerProvider
-import com.komoui.components.sonner.showSonner
 import com.komoui.themes.KomoTheme
 import com.komoui.demo.navigation.AppNavigation
 import com.komoui.demo.themes.ThemeEvent
@@ -30,7 +27,6 @@ import com.komoui.demo.themes.ThemeObserver
 import com.komoui.demo.themes.ThemeProvider
 import com.komoui.demo.themes.getStyles
 import com.komoui.demo.themes.isDarkTheme
-import kotlinx.coroutines.launch
 
 @Composable
 fun App(
@@ -51,19 +47,8 @@ fun App(
         komoLightColors = styles.first,
         komoDarkColors = styles.second
     ) {
-        val scope = rememberCoroutineScope()
-        val snackbarHostState = remember { SnackbarHostState() }
+        val snackbarHostState = rememberSonnerHostState()
         val navController = rememberNavController()
-        ObserveAsEvent(SonnerProvider.events) { event ->
-            scope.launch {
-                snackbarHostState.currentSnackbarData?.dismiss()
-                val result = snackbarHostState.showSonner(event)
-
-                if (result == SnackbarResult.ActionPerformed) {
-                    event.action?.execute()
-                }
-            }
-        }
         ThemeObserver(ThemeProvider.events) { event ->
             when (event) {
                 is ThemeEvent.Styles -> {

--- a/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/PopoverPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/komoui/demo/pages/components/PopoverPage.kt
@@ -42,6 +42,7 @@ fun PopoverPage() {
         ) {
             Popover(
                 open = showPopover,
+                onDismissRequest = { showPopover = false },
                 trigger = {
                     Button(onClick = { showPopover = !showPopover }) {
                         Text("Open Popover")

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Accordion.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 
@@ -130,10 +131,8 @@ fun Accordion(
                 ) {
                     // Header content
                     ProvideTextStyle(
-                        value = TextStyle(
-                            color = styles.foreground,
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Medium
+                        value = MaterialTheme.komoTypography.titleMedium.copy(
+                            color = styles.foreground
                         )
                     ) {
                         item.header()
@@ -163,9 +162,8 @@ fun Accordion(
                             .padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
                     ) {
                         ProvideTextStyle(
-                            value = TextStyle(
-                                color = styles.foreground,
-                                fontSize = 14.sp
+                            value = MaterialTheme.komoTypography.body.copy(
+                                color = styles.foreground
                             )
                         ) {
                             item.content()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Alert.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 enum class AlertVariant {
@@ -73,18 +74,13 @@ fun Alert(
 
         Column {
             ProvideTextStyle(
-                value = TextStyle(
-                    color = titleColor, fontSize = 16.sp, fontWeight = FontWeight.SemiBold
-                )
+                value = MaterialTheme.komoTypography.title.copy(color = titleColor)
             ) {
                 title()
             }
             Spacer(modifier = Modifier.height(4.dp))
             ProvideTextStyle(
-                value = TextStyle(
-                    color = descriptionColor,
-                    fontSize = 14.sp,
-                )
+                value = MaterialTheme.komoTypography.body.copy(color = descriptionColor)
             ) {
                 description()
             }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 /**
@@ -67,19 +68,16 @@ fun AlertDialog(
                 // Header (Title and Description)
                 Column(modifier = Modifier.fillMaxWidth()) {
                     ProvideTextStyle(
-                        value = TextStyle(
-                            color = styles.foreground,
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.SemiBold
+                        value = MaterialTheme.komoTypography.titleLarge.copy(
+                            color = styles.foreground
                         )
                     ) {
                         title()
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                     ProvideTextStyle(
-                        value = TextStyle(
-                            color = styles.mutedForeground,
-                            fontSize = 14.sp
+                        value = MaterialTheme.komoTypography.body.copy(
+                            color = styles.mutedForeground
                         )
                     ) {
                         description()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/AlertDialog.kt
@@ -40,12 +40,12 @@ import com.komoui.themes.styles
  */
 @Composable
 fun AlertDialog(
-    onDismissRequest: () -> Unit,
     open: Boolean,
-    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit,
     title: @Composable () -> Unit,
     description: @Composable () -> Unit,
     actions: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
     properties: DialogProperties = DialogProperties(
         dismissOnBackPress = false,
         dismissOnClickOutside = false

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Avatar.kt
@@ -45,10 +45,10 @@ import com.komoui.themes.styles
 @Composable
 fun Avatar(
     model: Any?,
+    fallbackText: String,
     modifier: Modifier = Modifier,
     size: Dp = 40.dp,
     contentDescription: String? = null,
-    fallbackText: String,
     loadingContent: @Composable (() -> Unit)? = null,
     errorContent: @Composable (() -> Unit)? = null,
     contentScale: ContentScale = ContentScale.Crop

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Badge.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -108,12 +109,7 @@ fun Badge(
     ) {
         if (content != null) {
             ProvideTextStyle(
-                value = TextStyle(
-                    color = resolvedContentColor,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
-                    lineHeight = 16.sp
-                )
+                value = MaterialTheme.komoTypography.labelMedium.copy(color = resolvedContentColor)
             ) {
                 content()
             }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Button.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.KomoStyles
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -227,10 +228,11 @@ fun Button(
     }
 
     // Common text style for buttons
-    val buttonTextStyle = TextStyle(
-        fontSize = if (size == ButtonSize.Xs) 12.sp else 14.sp,
-        fontWeight = FontWeight.Medium
-    )
+    val buttonTextStyle = if (size == ButtonSize.Xs) {
+        MaterialTheme.komoTypography.labelMedium
+    } else {
+        MaterialTheme.komoTypography.bodyMedium
+    }
 
     // For link variant, add underline
     val linkTextStyle = if (variant == ButtonVariant.Link) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -194,7 +194,9 @@ private fun DayOfWeek.toSundayStartIndex(): Int = when (this) {
  * @param modifier The modifier to be applied to the calendar container.
  * @param selectedDate The currently selected date. Null if no date is selected.
  * @param onDateSelected Callback invoked when a date is selected.
- * @param initialMonth The month to display initially. Defaults to current month.
+ * @param initialMonth The month to display initially in uncontrolled mode. Defaults to current month.
+ * @param month Controlled displayed month. Pass non-null (with [onMonthChange]) to drive navigation externally.
+ * @param onMonthChange Called when the displayed month changes (via arrows, pickers, or cross-month day taps).
  * @param dateSelectionMode Defines which dates are clickable (All, PastOrToday, FutureOrToday).
  * @param colors [CalendarStyle] that will be used to resolve the colors used for this calendar in
  */
@@ -204,6 +206,8 @@ fun Calendar(
     selectedDate: LocalDate? = null,
     onDateSelected: (LocalDate) -> Unit,
     initialMonth: YearMonth = YearMonth.now(),
+    month: YearMonth? = null,
+    onMonthChange: ((YearMonth) -> Unit)? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors()
 ) {
@@ -214,6 +218,8 @@ fun Calendar(
             onDateSelected = onDateSelected
         ),
         initialMonth = initialMonth,
+        month = month,
+        onMonthChange = onMonthChange,
         dateSelectionMode = dateSelectionMode,
         colors = colors
     )
@@ -225,7 +231,9 @@ fun Calendar(
  *
  * @param modifier The modifier to be applied to the calendar container.
  * @param selectionMode The selection mode (single or range).
- * @param initialMonth The month to display initially. Defaults to current month.
+ * @param initialMonth The month to display initially in uncontrolled mode. Defaults to current month.
+ * @param month Controlled displayed month. Pass non-null (with [onMonthChange]) to drive navigation externally.
+ * @param onMonthChange Called when the displayed month changes (via arrows, pickers, or cross-month day taps).
  * @param dateSelectionMode Defines which dates are clickable (All, PastOrToday, FutureOrToday).
  * @param colors [CalendarStyle] that will be used to resolve the colors used for this calendar in
  */
@@ -235,14 +243,21 @@ fun Calendar(
     modifier: Modifier = Modifier,
     selectionMode: CalendarSelectionMode,
     initialMonth: YearMonth = YearMonth.now(),
+    month: YearMonth? = null,
+    onMonthChange: ((YearMonth) -> Unit)? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors()
 ) {
     val themeColors = MaterialTheme.styles
     val radius = MaterialTheme.radius
     val strings = MaterialTheme.komoStrings
-    // Keyed on initialMonth so the view navigates when the caller changes it after first composition.
-    var currentMonth by remember(initialMonth) { mutableStateOf(initialMonth) }
+    // Controlled ([month] non-null) or uncontrolled (seeded by [initialMonth]) month navigation.
+    var internalMonth by remember(initialMonth) { mutableStateOf(initialMonth) }
+    val currentMonth = month ?: internalMonth
+    val setMonth: (YearMonth) -> Unit = { next ->
+        if (month == null) internalMonth = next
+        onMonthChange?.invoke(next)
+    }
     val today = remember {
         Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
     }
@@ -306,7 +321,7 @@ fun Calendar(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { currentMonth = currentMonth.minusMonths(1) }) {
+                IconButton(onClick = { setMonth(currentMonth.minusMonths(1)) }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Default.KeyboardArrowLeft,
                         contentDescription = "Previous Month",
@@ -371,7 +386,7 @@ fun Calendar(
                     }
                 }
 
-                IconButton(onClick = { currentMonth = currentMonth.plusMonths(1) }) {
+                IconButton(onClick = { setMonth(currentMonth.plusMonths(1)) }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Default.KeyboardArrowRight,
                         contentDescription = "Next Month",
@@ -592,7 +607,7 @@ fun Calendar(
                                         }
                                         // Navigate to the selected date's month if it's not current month
                                         if (!isCurrentMonth) {
-                                            currentMonth = YearMonth.from(date)
+                                            setMonth(YearMonth.from(date))
                                         }
                                         },
                                     )
@@ -616,8 +631,8 @@ fun Calendar(
     if (showMonthPicker) {
         MonthPickerDialog(
             currentMonth = currentMonth.month,
-            onMonthSelected = { month ->
-                currentMonth = currentMonth.withMonth(month.ordinal + 1)
+            onMonthSelected = { selected ->
+                setMonth(currentMonth.withMonth(selected.ordinal + 1))
                 showMonthPicker = false
             },
             onDismissRequest = { showMonthPicker = false },
@@ -630,7 +645,7 @@ fun Calendar(
         YearPickerDialog(
             currentYear = currentMonth.year,
             onYearSelected = { year ->
-                currentMonth = currentMonth.withYear(year)
+                setMonth(currentMonth.withYear(year))
                 showYearPicker = false
             },
             onDismissRequest = { showYearPicker = false },

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -208,6 +209,7 @@ fun Calendar(
     initialMonth: YearMonth = YearMonth.now(),
     month: YearMonth? = null,
     onMonthChange: ((YearMonth) -> Unit)? = null,
+    enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors()
 ) {
@@ -220,6 +222,7 @@ fun Calendar(
         initialMonth = initialMonth,
         month = month,
         onMonthChange = onMonthChange,
+        enabled = enabled,
         dateSelectionMode = dateSelectionMode,
         colors = colors
     )
@@ -245,6 +248,7 @@ fun Calendar(
     initialMonth: YearMonth = YearMonth.now(),
     month: YearMonth? = null,
     onMonthChange: ((YearMonth) -> Unit)? = null,
+    enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors()
 ) {
@@ -308,6 +312,7 @@ fun Calendar(
 
     Box(
         modifier = modifier
+            .alpha(if (enabled) 1f else 0.5f)
             .widthIn(max = 300.dp)
     ) {
         Column(
@@ -321,7 +326,7 @@ fun Calendar(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { setMonth(currentMonth.minusMonths(1)) }) {
+                IconButton(onClick = { setMonth(currentMonth.minusMonths(1)) }, enabled = enabled) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Default.KeyboardArrowLeft,
                         contentDescription = "Previous Month",
@@ -338,7 +343,7 @@ fun Calendar(
                         modifier = Modifier
                             .clip(RoundedCornerShape(radius.md))
                             .border(1.dp, colors.monthSelectorBorder, RoundedCornerShape(radius.md))
-                            .clickable { showMonthPicker = true }
+                            .clickable(enabled = enabled) { showMonthPicker = true }
                             .padding(horizontal = 8.dp, vertical = 6.dp)
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -364,7 +369,7 @@ fun Calendar(
                         modifier = Modifier
                             .clip(RoundedCornerShape(radius.md))
                             .border(1.dp, colors.yearSelectorBorder, RoundedCornerShape(radius.md))
-                            .clickable { showYearPicker = true }
+                            .clickable(enabled = enabled) { showYearPicker = true }
                             .padding(horizontal = 8.dp, vertical = 6.dp)
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -386,7 +391,7 @@ fun Calendar(
                     }
                 }
 
-                IconButton(onClick = { setMonth(currentMonth.plusMonths(1)) }) {
+                IconButton(onClick = { setMonth(currentMonth.plusMonths(1)) }, enabled = enabled) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Default.KeyboardArrowRight,
                         contentDescription = "Next Month",
@@ -478,7 +483,7 @@ fun Calendar(
                             val isToday = date == today
 
                             // Logic for date clickability based on dateSelectionMode
-                            val isClickable = when (dateSelectionMode) {
+                            val isClickable = enabled && when (dateSelectionMode) {
                                 DateSelectionMode.All -> true
                                 DateSelectionMode.PastOrToday -> date <= today
                                 DateSelectionMode.FutureOrToday -> date >= today

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -785,7 +785,6 @@ private fun YearPickerDialog(
 }
 
 data class CalendarStyle(
-    val background: Color,
     val border: Color,
     val leftIconTint: Color,
     val rightIconTint: Color,
@@ -830,7 +829,6 @@ object CalendarDefaults {
     @Composable
     private fun colorsFrom(colors: KomoStyles): CalendarStyle {
         return CalendarStyle(
-            background = colors.background,
             border = colors.border,
             leftIconTint = colors.foreground,
             rightIconTint = colors.foreground,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Calendar.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.window.Dialog
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoSelectable
 import kotlinx.datetime.DayOfWeek
@@ -302,13 +303,9 @@ fun Calendar(
         ).map { strings.weekdayNamesShort[it.ordinal] }
     }
 
-    // Pre-compute text styles used in the day grid
-    val dayTextStyleNormal = remember {
-        TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Normal)
-    }
-    val dayTextStyleBold = remember {
-        TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
-    }
+    // Text styles used in the day grid
+    val dayTextStyleNormal = MaterialTheme.komoTypography.body
+    val dayTextStyleBold = MaterialTheme.komoTypography.body.copy(fontWeight = FontWeight.SemiBold)
 
     Box(
         modifier = modifier
@@ -349,10 +346,7 @@ fun Calendar(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
                                 text = strings.monthNamesShort[currentMonth.month.ordinal],
-                                style = TextStyle(
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.Medium
-                                ),
+                                style = MaterialTheme.komoTypography.titleMedium,
                                 color = colors.monthText
                             )
                             Icon(
@@ -375,10 +369,7 @@ fun Calendar(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
                                 text = currentMonth.year.toString(),
-                                style = TextStyle(
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.Medium
-                                ),
+                                style = MaterialTheme.komoTypography.titleMedium,
                                 color = colors.yearText
                             )
                             Icon(
@@ -409,10 +400,8 @@ fun Calendar(
                         text = weekday,
                         modifier = Modifier.weight(1f),
                         textAlign = TextAlign.Center,
-                        style = TextStyle(
-                            color = colors.weekDaysText,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.Medium
+                        style = MaterialTheme.komoTypography.labelMedium.copy(
+                            color = colors.weekDaysText
                         )
                     )
                 }
@@ -716,10 +705,8 @@ private fun MonthPickerDialog(
                     ) {
                         Text(
                             text = MaterialTheme.komoStrings.monthNamesFull[month.ordinal],
-                            style = TextStyle(
-                                color = textColor,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Medium
+                            style = MaterialTheme.komoTypography.titleMedium.copy(
+                                color = textColor
                             )
                         )
                     }
@@ -791,10 +778,8 @@ private fun YearPickerDialog(
                     ) {
                         Text(
                             text = year.toString(),
-                            style = TextStyle(
-                                color = textColor,
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Medium
+                            style = MaterialTheme.komoTypography.titleMedium.copy(
+                                color = textColor
                             )
                         )
                     }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Card.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Card.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.BoxShadow
 import com.komoui.themes.drawShadows
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -95,11 +96,7 @@ fun CardTitle(
 ) {
     val styles = MaterialTheme.styles
     ProvideTextStyle(
-        value = TextStyle(
-            color = styles.cardForeground,
-            fontWeight = FontWeight.SemiBold,
-            fontSize = 18.sp
-        )
+        value = MaterialTheme.komoTypography.titleLarge.copy(color = styles.cardForeground)
     ) {
         Column(modifier = modifier) {
             content()
@@ -121,10 +118,7 @@ fun CardDescription(
 ) {
     val styles = MaterialTheme.styles
     ProvideTextStyle(
-        value = TextStyle(
-            color = styles.mutedForeground,
-            fontSize = 14.sp
-        )
+        value = MaterialTheme.komoTypography.body.copy(color = styles.mutedForeground)
     ) {
         Column(modifier = modifier) {
             content()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Carousel.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Carousel.kt
@@ -61,8 +61,9 @@ enum class CarouselOrientation {
  */
 @Composable
 fun Carousel(
-    containerModifier: Modifier = Modifier,
+    itemCount: Int,
     modifier: Modifier = Modifier,
+    containerModifier: Modifier = Modifier,
     state: PagerState? = null,
     autoScroll: Boolean = false,
     autoScrollDelayMillis: Long = 3000,
@@ -72,7 +73,6 @@ fun Carousel(
     showIndicator: Boolean = false,
     indicatorStyle: IndicatorStyle = CarouselDefaults.carouselIndicator(),
     itemSpacing: Dp = 8.dp,
-    itemCount: Int,
     pageSize: PageSize = PageSize.Fill,
     onItemChanged: ((Int) -> Unit)? = null,
     content: @Composable PagerScope.(position: Int) -> Unit

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Checkbox.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.utils.komoToggleable
@@ -35,7 +36,7 @@ import com.komoui.utils.komoToggleable
  * @param modifier The modifier to be applied to the checkbox.
  * @param enabled Controls the enabled state of the checkbox. When `false`, this checkbox will not
  *      be interactable.
- * @param colors [CheckboxColors] that will be used to resolve the colors used for this checkbox in
+ * @param colors [CheckboxStyle] that will be used to resolve the colors used for this checkbox in
  *      different states. See [CheckboxDefaults.colors].
  */
 @Composable
@@ -44,7 +45,7 @@ fun Checkbox(
     onCheckedChange: ((Boolean) -> Unit)?,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: CheckboxColors = CheckboxDefaults.colors()
+    colors: CheckboxStyle = CheckboxDefaults.colors()
 ) {
     val radius = MaterialTheme.radius
 
@@ -135,7 +136,7 @@ private data class ResolvedCheckboxColors(
  * @param checkedBorderColor Border color when checked.
  * @param uncheckedBorderColor Border color when unchecked.
  */
-data class CheckboxColors(
+data class CheckboxStyle(
     val checkedColor: Color,
     val uncheckedColor: Color,
     val disabledColor: Color,
@@ -150,15 +151,8 @@ data class CheckboxColors(
  * Contains the default values used by [Checkbox].
  */
 object CheckboxDefaults {
-    /**
-     * Creates a [CheckboxColors] with the default KomoUI color scheme.
-     *
-     * @return A [CheckboxColors] instance using the current theme's color palette.
-     */
-    @Composable
-    fun colors(): CheckboxColors {
-        val styles = MaterialTheme.styles
-        return CheckboxColors(
+    private fun colorsFrom(styles: KomoStyles): CheckboxStyle {
+        return CheckboxStyle(
             checkedColor = styles.primary,
             uncheckedColor = Color.Transparent,
             disabledColor = styles.muted,
@@ -169,4 +163,13 @@ object CheckboxDefaults {
             uncheckedBorderColor = styles.input
         )
     }
+
+    /** [CheckboxStyle] with the default KomoUI color scheme. */
+    @Composable
+    fun colors(): CheckboxStyle = colorsFrom(MaterialTheme.styles)
+
+    /** [CheckboxStyle] with the default scheme, mutated by [overrides]. */
+    @Composable
+    fun colors(overrides: CheckboxStyle.() -> CheckboxStyle): CheckboxStyle =
+        colorsFrom(MaterialTheme.styles).overrides()
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
 import com.komoui.themes.KomoFieldDefaults
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
@@ -78,6 +79,8 @@ fun ComboBox(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     placeholder: String = "Select option...",
+    isError: Boolean = false,
+    supportingText: String? = null,
     dropdownMaxHeight: Dp = 200.dp
 ) {
     val styles = MaterialTheme.styles
@@ -111,6 +114,7 @@ fun ComboBox(
 
     val currentBorderColor by animateColorAsState(
         targetValue = when {
+            isError -> styles.destructive
             !enabled -> styles.border
             isFocused || isPressed || expanded -> styles.ring
             else -> styles.border
@@ -177,6 +181,15 @@ fun ComboBox(
                     modifier = Modifier.size(20.dp)
                 )
             }
+        }
+
+        if (supportingText != null) {
+            Text(
+                text = supportingText,
+                color = if (isError) styles.destructive else styles.mutedForeground,
+                style = MaterialTheme.komoTypography.label,
+                modifier = Modifier.padding(top = 4.dp)
+            )
         }
 
         // Dropdown Popup

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
+import com.komoui.themes.FieldColors
 import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
@@ -81,6 +82,7 @@ fun ComboBox(
     placeholder: String = "Select option...",
     isError: Boolean = false,
     supportingText: String? = null,
+    colors: FieldColors = KomoFieldDefaults.colors(),
     dropdownMaxHeight: Dp = 200.dp
 ) {
     val styles = MaterialTheme.styles
@@ -114,15 +116,15 @@ fun ComboBox(
 
     val currentBorderColor by animateColorAsState(
         targetValue = when {
-            isError -> styles.destructive
-            !enabled -> styles.border
-            isFocused || isPressed || expanded -> styles.ring
-            else -> styles.border
+            isError -> colors.errorBorder
+            !enabled -> colors.border
+            isFocused || isPressed || expanded -> colors.focusedBorder
+            else -> colors.border
         },
         animationSpec = tween(150), label = "comboboxBorderColor"
     )
 
-    val textColor = if (enabled) styles.foreground else styles.mutedForeground
+    val textColor = if (enabled) colors.text else colors.placeholder
     val iconTint = styles.mutedForeground
     val containerBackground = if (enabled) Color.Transparent else styles.muted
 
@@ -170,7 +172,7 @@ fun ComboBox(
             ) {
                 Text(
                     text = selectedOption ?: placeholder,
-                    color = if (selectedOption != null) textColor else styles.mutedForeground,
+                    color = if (selectedOption != null) textColor else colors.placeholder,
                     style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
@@ -186,7 +188,7 @@ fun ComboBox(
         if (supportingText != null) {
             Text(
                 text = supportingText,
-                color = if (isError) styles.destructive else styles.mutedForeground,
+                color = if (isError) colors.errorSupportingText else colors.supportingText,
                 style = MaterialTheme.komoTypography.label,
                 modifier = Modifier.padding(top = 4.dp)
             )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
+import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
@@ -126,7 +127,7 @@ fun ComboBox(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp)
+                .height(KomoFieldDefaults.Height)
                 .onGloballyPositioned { coordinates ->
                     inputWidthPx = coordinates.size.width
                 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -171,7 +171,7 @@ fun ComboBox(
                 Text(
                     text = selectedOption ?: placeholder,
                     color = if (selectedOption != null) textColor else styles.mutedForeground,
-                    fontSize = 14.sp,
+                    style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
                 Icon(
@@ -267,7 +267,7 @@ fun ComboBox(
                                         Text(
                                             text = option,
                                             color = if (isSelected) styles.accentForeground else styles.popoverForeground,
-                                            fontSize = 14.sp,
+                                            style = MaterialTheme.komoTypography.body,
                                             modifier = Modifier.weight(1f)
                                         )
                                         if (isSelected) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Combobox.kt
@@ -42,12 +42,10 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
@@ -56,7 +54,7 @@ import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
-import kotlin.math.roundToInt
+import com.komoui.utils.rememberAnchoredPopupPositionProvider
 
 /**
  * A Jetpack Compose Combobox component for KomoUI's Dropdown Menu.
@@ -86,13 +84,10 @@ fun ComboBox(
     var expanded by remember { mutableStateOf(false) }
     var searchText by remember { mutableStateOf(selectedOption ?: "") }
 
-    // State to hold the position and width of the input field
+    // Width of the trigger, so the popup can match it. Position/flipping is handled by the provider.
     var inputWidthPx by remember { mutableIntStateOf(0) }
-    var inputHeightPx by remember { mutableIntStateOf(0) }
-    var inputXPositionPx by remember { mutableIntStateOf(0) }
-    var inputYPositionPx by remember { mutableIntStateOf(0) }
-
     val density = LocalDensity.current
+    val positionProvider = rememberAnchoredPopupPositionProvider()
 
     // Update searchText when selectedOption changes externally, but only if the dropdown is not expanded
     LaunchedEffect(selectedOption, expanded) {
@@ -134,10 +129,6 @@ fun ComboBox(
                 .height(48.dp)
                 .onGloballyPositioned { coordinates ->
                     inputWidthPx = coordinates.size.width
-                    inputHeightPx = coordinates.size.height
-                    val position = coordinates.parentLayoutCoordinates?.windowToLocal(coordinates.positionInWindow())
-                    inputXPositionPx = position?.x?.roundToInt() ?: 0
-                    inputYPositionPx = position?.y?.roundToInt() ?: 0
                 }
                 .clip(RoundedCornerShape(radius.md))
                 .background(containerBackground)
@@ -190,7 +181,7 @@ fun ComboBox(
         // Dropdown Popup
         if (expanded) {
             Popup(
-                offset = IntOffset(inputXPositionPx, inputYPositionPx + inputHeightPx),
+                popupPositionProvider = positionProvider,
                 properties = PopupProperties(focusable = true),
                 onDismissRequest = {
                     expanded = false

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -252,7 +252,7 @@ private fun DatePickerScaffold(
                 Text(
                     text = displayText ?: placeholder,
                     color = if (hasValue) themeColors.foreground else themeColors.mutedForeground,
-                    fontSize = 14.sp,
+                    style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
                 if (trailingIcon != null) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -94,20 +94,6 @@ class DateFormatter(private val pattern: String) {
     }
 }
 
-/**
- * A Jetpack Compose Date Picker component for KomoUI.
- * It combines a clickable input field with a popover containing a calendar.
- *
- * @param modifier The modifier to be applied to the date picker container.
- * @param selectedDate The currently selected date. Null if no date is selected.
- * @param dateTimeFormat The format to use for displaying the selected date.
- * @param onDateSelected Callback invoked when a date is selected.
- * @param placeholder The placeholder text to display when no date is selected.
- * @param dateSelectionMode Defines which dates are clickable in the calendar (All, PastOrToday, FutureOrToday).
- * @param colors [CalendarStyle] that will be used to resolve the colors used for this input in
- * @param leadingIcon Optional composable to display at the start of the input field.
- * @param trailingIcon Optional composable to display at the end of the input field.
- */
 @Composable
 fun DatePicker(
     modifier: Modifier = Modifier,
@@ -120,14 +106,91 @@ fun DatePicker(
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null
 ) {
+    val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
+    val formattedDate = selectedDate?.let { formatter.format(it) }
+
+    DatePickerScaffold(
+        modifier = modifier,
+        displayText = formattedDate,
+        hasValue = selectedDate != null,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+    ) { onDismiss ->
+        Calendar(
+            selectionMode = CalendarSelectionMode.Single(
+                selectedDate = selectedDate,
+                onDateSelected = { date ->
+                    onDateSelected(date)
+                    onDismiss()
+                }
+            ),
+            initialMonth = selectedDate?.let { YearMonth.from(it) } ?: YearMonth.now(),
+            dateSelectionMode = dateSelectionMode,
+            colors = colors
+        )
+    }
+}
+
+@Composable
+fun DateRangePicker(
+    modifier: Modifier = Modifier,
+    selectedRange: DateRange? = null,
+    dateTimeFormat: DateFormatter? = null,
+    onRangeSelected: (DateRange) -> Unit,
+    placeholder: String = "Pick a date range",
+    dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
+    colors: CalendarStyle = CalendarDefaults.colors(),
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null
+) {
+    val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
+    val formattedRange = selectedRange?.let {
+        "${formatter.format(it.start)} - ${formatter.format(it.end)}"
+    }
+
+    DatePickerScaffold(
+        modifier = modifier,
+        displayText = formattedRange,
+        hasValue = selectedRange != null,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+    ) { onDismiss ->
+        Calendar(
+            selectionMode = CalendarSelectionMode.Range(
+                selectedRange = selectedRange,
+                onRangeSelected = { range ->
+                    onRangeSelected(range)
+                    onDismiss()
+                }
+            ),
+            initialMonth = selectedRange?.start?.let { YearMonth.from(it) } ?: YearMonth.now(),
+            dateSelectionMode = dateSelectionMode,
+            colors = colors
+        )
+    }
+}
+
+/**
+ * Shared trigger + popup scaffold behind [DatePicker] and [DateRangePicker]. Renders the bordered
+ * input field showing [displayText] (or [placeholder]) and hosts [popover] in an anchored popup,
+ * passing it a dismiss callback to close after a selection.
+ */
+@Composable
+private fun DatePickerScaffold(
+    modifier: Modifier,
+    displayText: String?,
+    hasValue: Boolean,
+    placeholder: String,
+    leadingIcon: @Composable (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    popover: @Composable (onDismiss: () -> Unit) -> Unit,
+) {
     val themeColors = MaterialTheme.styles
     val radius = MaterialTheme.radius
     var showCalendarPopup by remember { mutableStateOf(false) }
-
     val positionProvider = rememberAnchoredPopupPositionProvider()
-
-    val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
-    val formattedDate = selectedDate?.let { formatter.format(it) }
 
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -164,8 +227,8 @@ fun DatePicker(
                     Spacer(modifier = Modifier.width(8.dp))
                 }
                 Text(
-                    text = formattedDate ?: placeholder,
-                    color = if (selectedDate != null) themeColors.foreground else themeColors.mutedForeground,
+                    text = displayText ?: placeholder,
+                    color = if (hasValue) themeColors.foreground else themeColors.mutedForeground,
                     fontSize = 14.sp,
                     modifier = Modifier.weight(1f)
                 )
@@ -173,11 +236,9 @@ fun DatePicker(
                     Spacer(modifier = Modifier.width(8.dp))
                     trailingIcon()
                 }
-
             }
         }
 
-        // Calendar Popup
         if (showCalendarPopup) {
             Popup(
                 popupPositionProvider = positionProvider,
@@ -189,132 +250,7 @@ fun DatePicker(
                         .clip(RoundedCornerShape(radius.md))
                         .background(themeColors.popover)
                 ) {
-                    Calendar(
-                        selectionMode = CalendarSelectionMode.Single(
-                            selectedDate = selectedDate,
-                            onDateSelected = { date ->
-                                onDateSelected(date)
-                                showCalendarPopup = false
-                            }
-                        ),
-                        initialMonth = selectedDate?.let { YearMonth.from(it) } ?: YearMonth.now(),
-                        dateSelectionMode = dateSelectionMode,
-                        colors = colors
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * A Jetpack Compose Date Range Picker component for KomoUI.
- * It combines a clickable input field with a popover containing a range-selection calendar.
- *
- * @param modifier The modifier to be applied to the date range picker container.
- * @param selectedRange The currently selected date range. Null if no range is selected.
- * @param dateTimeFormat The format to use for displaying the selected dates.
- * @param onRangeSelected Callback invoked when a complete date range is selected.
- * @param placeholder The placeholder text to display when no range is selected.
- * @param dateSelectionMode Defines which dates are clickable in the calendar (All, PastOrToday, FutureOrToday).
- * @param colors [CalendarStyle] that will be used to resolve the colors used for this input in
- * @param leadingIcon Optional composable to display at the start of the input field.
- * @param trailingIcon Optional composable to display at the end of the input field.
- */
-@Composable
-fun DateRangePicker(
-    modifier: Modifier = Modifier,
-    selectedRange: DateRange? = null,
-    dateTimeFormat: DateFormatter? = null,
-    onRangeSelected: (DateRange) -> Unit,
-    placeholder: String = "Pick a date range",
-    dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
-    colors: CalendarStyle = CalendarDefaults.colors(),
-    leadingIcon: @Composable (() -> Unit)? = null,
-    trailingIcon: @Composable (() -> Unit)? = null
-) {
-    val themeColors = MaterialTheme.styles
-    val radius = MaterialTheme.radius
-    var showCalendarPopup by remember { mutableStateOf(false) }
-
-    val positionProvider = rememberAnchoredPopupPositionProvider()
-
-    val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
-    val formattedRange = selectedRange?.let {
-        "${formatter.format(it.start)} - ${formatter.format(it.end)}"
-    }
-
-    val interactionSource = remember { MutableInteractionSource() }
-    val isFocused by interactionSource.collectIsFocusedAsState()
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val currentBorderColor by animateColorAsState(
-        targetValue = if (isFocused || isPressed || showCalendarPopup) themeColors.ring else themeColors.border,
-        animationSpec = tween(150), label = "dateRangePickerBorderColor"
-    )
-
-    Column(modifier = modifier) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp)
-                .clip(RoundedCornerShape(radius.md))
-                .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
-                .komoClickable(
-                    onClick = { showCalendarPopup = !showCalendarPopup },
-                    role = Role.DropdownList,
-                    shape = RoundedCornerShape(radius.md),
-                    stateDescription = if (showCalendarPopup) "Expanded" else "Collapsed",
-                    interactionSource = interactionSource,
-                )
-                .padding(horizontal = 12.dp),
-            contentAlignment = Alignment.CenterStart
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                if (leadingIcon != null) {
-                    leadingIcon()
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(
-                    text = formattedRange ?: placeholder,
-                    color = if (selectedRange != null) themeColors.foreground else themeColors.mutedForeground,
-                    fontSize = 14.sp,
-                    modifier = Modifier.weight(1f)
-                )
-                if (trailingIcon != null) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    trailingIcon()
-                }
-            }
-        }
-
-        // Calendar Popup
-        if (showCalendarPopup) {
-            Popup(
-                popupPositionProvider = positionProvider,
-                properties = PopupProperties(focusable = true),
-                onDismissRequest = { showCalendarPopup = false }
-            ) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(radius.md))
-                        .background(themeColors.popover)
-                ) {
-                    Calendar(
-                        selectionMode = CalendarSelectionMode.Range(
-                            selectedRange = selectedRange,
-                            onRangeSelected = { range ->
-                                onRangeSelected(range)
-                                showCalendarPopup = false
-                            }
-                        ),
-                        initialMonth = selectedRange?.start?.let { YearMonth.from(it) } ?: YearMonth.now(),
-                        dateSelectionMode = dateSelectionMode,
-                        colors = colors
-                    )
+                    popover { showCalendarPopup = false }
                 }
             }
         }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -21,17 +21,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
@@ -39,8 +35,8 @@ import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
+import com.komoui.utils.rememberAnchoredPopupPositionProvider
 import kotlinx.datetime.LocalDate
-import kotlin.math.roundToInt
 
 class DateFormatter(private val pattern: String) {
     /**
@@ -128,9 +124,7 @@ fun DatePicker(
     val radius = MaterialTheme.radius
     var showCalendarPopup by remember { mutableStateOf(false) }
 
-    var inputHeightPx by remember { mutableIntStateOf(0) }
-    var inputXPositionPx by remember { mutableIntStateOf(0) }
-    var inputYPositionPx by remember { mutableIntStateOf(0) }
+    val positionProvider = rememberAnchoredPopupPositionProvider()
 
     val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
     val formattedDate = selectedDate?.let { formatter.format(it) }
@@ -148,13 +142,6 @@ fun DatePicker(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp)
-                .onGloballyPositioned { coordinates ->
-                    // Get the size and position of the input field
-                    inputHeightPx = coordinates.size.height
-                    val position = coordinates.parentLayoutCoordinates?.windowToLocal(coordinates.positionInWindow())
-                    inputXPositionPx = position?.x?.roundToInt() ?: 0
-                    inputYPositionPx = position?.y?.roundToInt() ?: 0
-                }
                 .clip(RoundedCornerShape(radius.md))
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .komoClickable(
@@ -193,7 +180,7 @@ fun DatePicker(
         // Calendar Popup
         if (showCalendarPopup) {
             Popup(
-                offset = IntOffset(inputXPositionPx, inputYPositionPx + inputHeightPx),
+                popupPositionProvider = positionProvider,
                 properties = PopupProperties(focusable = true),
                 onDismissRequest = { showCalendarPopup = false }
             ) {
@@ -250,9 +237,7 @@ fun DateRangePicker(
     val radius = MaterialTheme.radius
     var showCalendarPopup by remember { mutableStateOf(false) }
 
-    var inputHeightPx by remember { mutableIntStateOf(0) }
-    var inputXPositionPx by remember { mutableIntStateOf(0) }
-    var inputYPositionPx by remember { mutableIntStateOf(0) }
+    val positionProvider = rememberAnchoredPopupPositionProvider()
 
     val formatter = dateTimeFormat ?: DateFormatter.ofPattern("MMM dd, yyyy")
     val formattedRange = selectedRange?.let {
@@ -272,12 +257,6 @@ fun DateRangePicker(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp)
-                .onGloballyPositioned { coordinates ->
-                    inputHeightPx = coordinates.size.height
-                    val position = coordinates.parentLayoutCoordinates?.windowToLocal(coordinates.positionInWindow())
-                    inputXPositionPx = position?.x?.roundToInt() ?: 0
-                    inputYPositionPx = position?.y?.roundToInt() ?: 0
-                }
                 .clip(RoundedCornerShape(radius.md))
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .komoClickable(
@@ -315,7 +294,7 @@ fun DateRangePicker(
         // Calendar Popup
         if (showCalendarPopup) {
             Popup(
-                offset = IntOffset(inputXPositionPx, inputYPositionPx + inputHeightPx),
+                popupPositionProvider = positionProvider,
                 properties = PopupProperties(focusable = true),
                 onDismissRequest = { showCalendarPopup = false }
             ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -98,10 +98,10 @@ class DateFormatter(private val pattern: String) {
 
 @Composable
 fun DatePicker(
+    onDateSelected: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
     selectedDate: LocalDate? = null,
     dateTimeFormat: DateFormatter? = null,
-    onDateSelected: (LocalDate) -> Unit,
     placeholder: String = "Pick a date",
     enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
@@ -138,10 +138,10 @@ fun DatePicker(
 
 @Composable
 fun DateRangePicker(
+    onRangeSelected: (DateRange) -> Unit,
     modifier: Modifier = Modifier,
     selectedRange: DateRange? = null,
     dateTimeFormat: DateFormatter? = null,
-    onRangeSelected: (DateRange) -> Unit,
     placeholder: String = "Pick a date range",
     enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
+import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
@@ -204,7 +205,7 @@ private fun DatePickerScaffold(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp)
+                .height(KomoFieldDefaults.Height)
                 .clip(RoundedCornerShape(radius.md))
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .komoClickable(

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -102,6 +103,7 @@ fun DatePicker(
     dateTimeFormat: DateFormatter? = null,
     onDateSelected: (LocalDate) -> Unit,
     placeholder: String = "Pick a date",
+    enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -115,6 +117,7 @@ fun DatePicker(
         displayText = formattedDate,
         hasValue = selectedDate != null,
         placeholder = placeholder,
+        enabled = enabled,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -140,6 +143,7 @@ fun DateRangePicker(
     dateTimeFormat: DateFormatter? = null,
     onRangeSelected: (DateRange) -> Unit,
     placeholder: String = "Pick a date range",
+    enabled: Boolean = true,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -155,6 +159,7 @@ fun DateRangePicker(
         displayText = formattedRange,
         hasValue = selectedRange != null,
         placeholder = placeholder,
+        enabled = enabled,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -184,6 +189,7 @@ private fun DatePickerScaffold(
     displayText: String?,
     hasValue: Boolean,
     placeholder: String,
+    enabled: Boolean,
     leadingIcon: @Composable (() -> Unit)?,
     trailingIcon: @Composable (() -> Unit)?,
     popover: @Composable (onDismiss: () -> Unit) -> Unit,
@@ -201,7 +207,7 @@ private fun DatePickerScaffold(
         animationSpec = tween(150), label = "datePickerBorderColor"
     )
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.alpha(if (enabled) 1f else 0.5f)) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -210,6 +216,7 @@ private fun DatePickerScaffold(
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .komoClickable(
                     onClick = { showCalendarPopup = !showCalendarPopup },
+                    enabled = enabled,
                     role = Role.DropdownList,
                     shape = RoundedCornerShape(radius.md),
                     stateDescription = if (showCalendarPopup) "Expanded" else "Collapsed",

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
+import com.komoui.themes.FieldColors
 import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
@@ -109,6 +110,7 @@ fun DatePicker(
     supportingText: String? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
+    fieldColors: FieldColors = KomoFieldDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null
 ) {
@@ -123,6 +125,7 @@ fun DatePicker(
         enabled = enabled,
         isError = isError,
         supportingText = supportingText,
+        colors = fieldColors,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -153,6 +156,7 @@ fun DateRangePicker(
     supportingText: String? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
+    fieldColors: FieldColors = KomoFieldDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null
 ) {
@@ -169,6 +173,7 @@ fun DateRangePicker(
         enabled = enabled,
         isError = isError,
         supportingText = supportingText,
+        colors = fieldColors,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -201,6 +206,7 @@ private fun DatePickerScaffold(
     enabled: Boolean,
     isError: Boolean,
     supportingText: String?,
+    colors: FieldColors,
     leadingIcon: @Composable (() -> Unit)?,
     trailingIcon: @Composable (() -> Unit)?,
     popover: @Composable (onDismiss: () -> Unit) -> Unit,
@@ -215,9 +221,9 @@ private fun DatePickerScaffold(
     val isPressed by interactionSource.collectIsPressedAsState()
     val currentBorderColor by animateColorAsState(
         targetValue = when {
-            isError -> themeColors.destructive
-            isFocused || isPressed || showCalendarPopup -> themeColors.ring
-            else -> themeColors.border
+            isError -> colors.errorBorder
+            isFocused || isPressed || showCalendarPopup -> colors.focusedBorder
+            else -> colors.border
         },
         animationSpec = tween(150), label = "datePickerBorderColor"
     )
@@ -251,7 +257,7 @@ private fun DatePickerScaffold(
                 }
                 Text(
                     text = displayText ?: placeholder,
-                    color = if (hasValue) themeColors.foreground else themeColors.mutedForeground,
+                    color = if (hasValue) colors.text else colors.placeholder,
                     style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
@@ -265,7 +271,7 @@ private fun DatePickerScaffold(
         if (supportingText != null) {
             Text(
                 text = supportingText,
-                color = if (isError) themeColors.destructive else themeColors.mutedForeground,
+                color = if (isError) colors.errorSupportingText else colors.supportingText,
                 style = MaterialTheme.komoTypography.label,
                 modifier = Modifier.padding(top = 4.dp)
             )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DatePicker.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.KomoFieldDefaults
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
@@ -104,6 +105,8 @@ fun DatePicker(
     dateTimeFormat: DateFormatter? = null,
     placeholder: String = "Pick a date",
     enabled: Boolean = true,
+    isError: Boolean = false,
+    supportingText: String? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -118,6 +121,8 @@ fun DatePicker(
         hasValue = selectedDate != null,
         placeholder = placeholder,
         enabled = enabled,
+        isError = isError,
+        supportingText = supportingText,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -144,6 +149,8 @@ fun DateRangePicker(
     dateTimeFormat: DateFormatter? = null,
     placeholder: String = "Pick a date range",
     enabled: Boolean = true,
+    isError: Boolean = false,
+    supportingText: String? = null,
     dateSelectionMode: DateSelectionMode = DateSelectionMode.All,
     colors: CalendarStyle = CalendarDefaults.colors(),
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -160,6 +167,8 @@ fun DateRangePicker(
         hasValue = selectedRange != null,
         placeholder = placeholder,
         enabled = enabled,
+        isError = isError,
+        supportingText = supportingText,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
     ) { onDismiss ->
@@ -190,6 +199,8 @@ private fun DatePickerScaffold(
     hasValue: Boolean,
     placeholder: String,
     enabled: Boolean,
+    isError: Boolean,
+    supportingText: String?,
     leadingIcon: @Composable (() -> Unit)?,
     trailingIcon: @Composable (() -> Unit)?,
     popover: @Composable (onDismiss: () -> Unit) -> Unit,
@@ -203,7 +214,11 @@ private fun DatePickerScaffold(
     val isFocused by interactionSource.collectIsFocusedAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
     val currentBorderColor by animateColorAsState(
-        targetValue = if (isFocused || isPressed || showCalendarPopup) themeColors.ring else themeColors.border,
+        targetValue = when {
+            isError -> themeColors.destructive
+            isFocused || isPressed || showCalendarPopup -> themeColors.ring
+            else -> themeColors.border
+        },
         animationSpec = tween(150), label = "datePickerBorderColor"
     )
 
@@ -245,6 +260,15 @@ private fun DatePickerScaffold(
                     trailingIcon()
                 }
             }
+        }
+
+        if (supportingText != null) {
+            Text(
+                text = supportingText,
+                color = if (isError) themeColors.destructive else themeColors.mutedForeground,
+                style = MaterialTheme.komoTypography.label,
+                modifier = Modifier.padding(top = 4.dp)
+            )
         }
 
         if (showCalendarPopup) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import androidx.compose.ui.window.Dialog as ComposeDialog
 import androidx.compose.ui.window.DialogProperties
@@ -126,10 +127,8 @@ fun DialogTitle(
     content: @Composable () -> Unit
 ) {
     ProvideTextStyle(
-        value = TextStyle(
-            color = MaterialTheme.styles.foreground,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.SemiBold
+        value = MaterialTheme.komoTypography.titleLarge.copy(
+            color = MaterialTheme.styles.foreground
         )
     ) {
         Column(modifier = modifier) {
@@ -148,9 +147,8 @@ fun DialogDescription(
     content: @Composable () -> Unit
 ) {
     ProvideTextStyle(
-        value = TextStyle(
-            color = MaterialTheme.styles.mutedForeground,
-            fontSize = 14.sp
+        value = MaterialTheme.komoTypography.body.copy(
+            color = MaterialTheme.styles.mutedForeground
         )
     ) {
         Column(modifier = modifier) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Dialog.kt
@@ -48,8 +48,8 @@ import androidx.compose.ui.window.DialogProperties
  */
 @Composable
 fun Dialog(
-    onDismissRequest: () -> Unit,
     open: Boolean,
+    onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     header: (@Composable ColumnScope.() -> Unit)? = null,
     body: (@Composable ColumnScope.() -> Unit)? = null,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
 import com.komoui.themes.komoStrings
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 /**
@@ -164,19 +165,16 @@ fun Drawer(
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         ProvideTextStyle(
-                            value = TextStyle(
-                                color = styles.foreground,
-                                fontSize = 18.sp,
-                                fontWeight = FontWeight.SemiBold
+                            value = MaterialTheme.komoTypography.titleLarge.copy(
+                                color = styles.foreground
                             )
                         ) {
                             title()
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                         ProvideTextStyle(
-                            value = TextStyle(
-                                color = styles.mutedForeground,
-                                fontSize = 14.sp
+                            value = MaterialTheme.komoTypography.body.copy(
+                                color = styles.mutedForeground
                             )
                         ) {
                             description()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Drawer.kt
@@ -65,8 +65,8 @@ import com.komoui.themes.styles
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Drawer(
-    onDismissRequest: () -> Unit,
     open: Boolean,
+    onDismissRequest: () -> Unit,
     title: @Composable () -> Unit,
     description: @Composable () -> Unit,
     modifier: Modifier = Modifier,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/DropdownMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/DropdownMenu.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 // --- 3. Dropdown Menu Components ---
@@ -115,11 +116,7 @@ fun DropdownMenuItem(
     ComposeDropdownMenuItem(
         text = {
             ProvideTextStyle(
-                value = TextStyle(
-                    color = contentColor,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Normal
-                )
+                value = MaterialTheme.komoTypography.body.copy(color = contentColor)
             ) {
                 Row(
                     horizontalArrangement = Arrangement.Start,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Empty.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Empty.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 enum class EmptyMediaVariant {
@@ -132,10 +133,9 @@ fun EmptyTitle(
 ) {
     val styles = MaterialTheme.styles
     ProvideTextStyle(
-        value = TextStyle(
+        value = MaterialTheme.komoTypography.titleLarge.copy(
             color = styles.foreground,
             fontWeight = FontWeight.Medium,
-            fontSize = 18.sp,
             letterSpacing = (-0.2).sp
         )
     ) {
@@ -158,9 +158,8 @@ fun EmptyDescription(
 ) {
     val styles = MaterialTheme.styles
     ProvideTextStyle(
-        value = TextStyle(
+        value = MaterialTheme.komoTypography.body.copy(
             color = styles.mutedForeground,
-            fontSize = 14.sp,
             lineHeight = 22.sp
         )
     ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
 import com.komoui.themes.KomoFieldDefaults
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 enum class InputVariant {
@@ -155,11 +156,7 @@ fun Input(
                 .then(borderStyle),
             enabled = enabled,
             readOnly = readOnly,
-            textStyle = TextStyle(
-                color = textColor,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Normal
-            ),
+            textStyle = MaterialTheme.komoTypography.body.copy(color = textColor),
             visualTransformation = visualTransformation,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
@@ -190,10 +187,8 @@ fun Input(
                         if (value.isEmpty()) {
                             Text(
                                 text = placeholder,
-                                style = TextStyle(
-                                    color = placeholderColor,
-                                    fontSize = 14.sp,
-                                    fontWeight = FontWeight.Normal
+                                style = MaterialTheme.komoTypography.body.copy(
+                                    color = placeholderColor
                                 )
                             )
                         }
@@ -215,9 +210,8 @@ fun Input(
         supportingText?.let {
             Spacer(modifier = Modifier.height(2.dp))
             ProvideTextStyle(
-                value = TextStyle(
-                    color = colors.supportingText,
-                    fontSize = 12.sp
+                value = MaterialTheme.komoTypography.label.copy(
+                    color = colors.supportingText
                 )
             ) {
                 it()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Input.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
+import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
 
 enum class InputVariant {
@@ -147,7 +148,7 @@ fun Input(
             onValueChange = onValueChange,
             modifier = Modifier
                 .fillMaxWidth()
-                .defaultMinSize(minHeight = 44.dp)
+                .defaultMinSize(minHeight = KomoFieldDefaults.Height)
                 // Expose the error state to screen readers (visual-only border color otherwise).
                 .then(if (isError) Modifier.semantics { error("Invalid input") } else Modifier)
                 .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)

--- a/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/InputOTP.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 data class InputOTPBorderStyle(
@@ -229,10 +230,8 @@ private fun InputOTPSlot(
         if (char != null) {
             Text(
                 text = char.toString(),
-                style = TextStyle(
-                    color = if (enabled) colors.text else colors.disableText,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
+                style = MaterialTheme.komoTypography.bodyMedium.copy(
+                    color = if (enabled) colors.text else colors.disableText
                 )
             )
         } else if (isActive) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
@@ -23,9 +23,9 @@ import com.komoui.utils.rememberAnchoredPopupPositionProvider
 @Composable
 fun Popover(
     open: Boolean,
-    modifier: Modifier = Modifier,
-    onDismissRequest: (() -> Unit)? = null,
+    onDismissRequest: () -> Unit,
     trigger: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
     val styles = MaterialTheme.styles

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
@@ -9,21 +9,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupPositionProvider
 import com.komoui.themes.radius
 import com.komoui.themes.styles
+import com.komoui.utils.PopupAlignment
+import com.komoui.utils.rememberAnchoredPopupPositionProvider
 
 @Composable
 fun Popover(
@@ -35,24 +30,10 @@ fun Popover(
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
-    val gapPx = with(LocalDensity.current) { 8.dp.roundToPx() }
 
-    // Centers the popup horizontally under the anchor using the measured popup size,
-    // so true centering works regardless of density or popup width.
-    val positionProvider = remember(gapPx) {
-        object : PopupPositionProvider {
-            override fun calculatePosition(
-                anchorBounds: IntRect,
-                windowSize: IntSize,
-                layoutDirection: LayoutDirection,
-                popupContentSize: IntSize
-            ): IntOffset {
-                val x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
-                val y = anchorBounds.bottom + gapPx
-                return IntOffset(x, y)
-            }
-        }
-    }
+    // Centers the popup under the anchor, flips it above when there's no room below, and clamps
+    // it within the window.
+    val positionProvider = rememberAnchoredPopupPositionProvider(gap = 8.dp, alignment = PopupAlignment.Center)
 
     Box {
         trigger()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Popover.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.utils.PopupAlignment
@@ -53,9 +54,8 @@ fun Popover(
                             .padding(12.dp)
                     ) {
                         ProvideTextStyle(
-                            value = TextStyle(
-                                color = styles.popoverForeground,
-                                fontSize = 14.sp
+                            value = MaterialTheme.komoTypography.body.copy(
+                                color = styles.popoverForeground
                             )
                         ) {
                             content()

--- a/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoSelectable
 
@@ -126,10 +127,8 @@ fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
         )
         Text(
             text = label,
-            style = TextStyle(
-                color = if (enabled) themeColors.foreground else themeColors.mutedForeground,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Medium
+            style = MaterialTheme.komoTypography.bodyMedium.copy(
+                color = if (enabled) themeColors.foreground else themeColors.mutedForeground
             )
         )
     }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/RadioButton.kt
@@ -9,17 +9,15 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.minimumInteractiveComponentSize
-import androidx.compose.material3.RadioButtonColors
-import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.RadioButtonDefaults as M3RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.komoui.themes.KomoStyles
 import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoSelectable
@@ -87,7 +85,7 @@ enum class LayoutOrientation {
  * @param label The text label for this radio button.
  * @param modifier The modifier to be applied to the row containing the radio button and label.
  * @param enabled Controls the enabled state of the radio button and label.
- * @param colors Optional custom colors for the radio button and label.
+ * @param colors The [RadioButtonStyle] for the radio button and label. See [RadioButtonDefaults.colors].
  */
 @Composable
 fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
@@ -95,9 +93,8 @@ fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
     label: String,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: RadioButtonColors? = null
+    colors: RadioButtonStyle = RadioButtonDefaults.colors()
 ) {
-    val themeColors = MaterialTheme.styles
     val isSelected = (selectedValue == value)
 
     Row(
@@ -117,19 +114,49 @@ fun <T> RadioGroupScope<T>.RadioButtonWithLabel(
             selected = isSelected,
             onClick = null,
             enabled = enabled,
-            colors = colors ?: RadioButtonDefaults.colors(
-                selectedColor = MaterialTheme.styles.primary,
-                unselectedColor = MaterialTheme.styles.input,
-                disabledSelectedColor = MaterialTheme.styles.primary.copy(alpha = 0.5f),
-                disabledUnselectedColor = MaterialTheme.styles.mutedForeground.copy(alpha = 0.5f)
+            colors = M3RadioButtonDefaults.colors(
+                selectedColor = colors.selected,
+                unselectedColor = colors.unselected,
+                disabledSelectedColor = colors.disabledSelected,
+                disabledUnselectedColor = colors.disabledUnselected
             ),
             modifier = Modifier.size(24.dp)
         )
         Text(
             text = label,
             style = MaterialTheme.komoTypography.bodyMedium.copy(
-                color = if (enabled) themeColors.foreground else themeColors.mutedForeground
+                color = if (enabled) colors.label else colors.disabledLabel
             )
         )
     }
+}
+
+/** Colors used by a [RadioButtonWithLabel]. */
+data class RadioButtonStyle(
+    val selected: Color,
+    val unselected: Color,
+    val disabledSelected: Color,
+    val disabledUnselected: Color,
+    val label: Color,
+    val disabledLabel: Color,
+)
+
+object RadioButtonDefaults {
+    private fun colorsFrom(styles: KomoStyles): RadioButtonStyle = RadioButtonStyle(
+        selected = styles.primary,
+        unselected = styles.input,
+        disabledSelected = styles.primary.copy(alpha = 0.5f),
+        disabledUnselected = styles.mutedForeground.copy(alpha = 0.5f),
+        label = styles.foreground,
+        disabledLabel = styles.mutedForeground,
+    )
+
+    /** [RadioButtonStyle] with the default KomoUI color scheme. */
+    @Composable
+    fun colors(): RadioButtonStyle = colorsFrom(MaterialTheme.styles)
+
+    /** [RadioButtonStyle] with the default scheme, mutated by [overrides]. */
+    @Composable
+    fun colors(overrides: RadioButtonStyle.() -> RadioButtonStyle): RadioButtonStyle =
+        colorsFrom(MaterialTheme.styles).overrides()
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
+import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
@@ -111,7 +112,7 @@ fun <T> Select(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp)
+                .height(KomoFieldDefaults.Height)
                 .onGloballyPositioned { coordinates ->
                     inputWidthPx = coordinates.size.width
                 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
+import com.komoui.themes.FieldColors
 import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
 import com.komoui.themes.komoTypography
@@ -83,7 +84,8 @@ fun <T> Select(
     enabled: Boolean = true,
     placeholder: String = "Select option...",
     isError: Boolean = false,
-    supportingText: String? = null
+    supportingText: String? = null,
+    colors: FieldColors = KomoFieldDefaults.colors()
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
@@ -100,9 +102,9 @@ fun <T> Select(
 
     val currentBorderColor by animateColorAsState(
         targetValue = when {
-            isError -> styles.destructive
-            enabled && (isFocused || isPressed || expanded) -> styles.ring
-            else -> styles.border
+            isError -> colors.errorBorder
+            enabled && (isFocused || isPressed || expanded) -> colors.focusedBorder
+            else -> colors.border
         },
         animationSpec = tween(150), label = "selectBorderColor"
     )
@@ -144,7 +146,7 @@ fun <T> Select(
                 // Display selected option or placeholder
                 Text(
                     text = displayText ?: placeholder,
-                    color = if (displayText != null) styles.foreground else styles.mutedForeground,
+                    color = if (displayText != null) colors.text else colors.placeholder,
                     style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
@@ -162,7 +164,7 @@ fun <T> Select(
         if (supportingText != null) {
             Text(
                 text = supportingText,
-                color = if (isError) styles.destructive else styles.mutedForeground,
+                color = if (isError) colors.errorSupportingText else colors.supportingText,
                 style = MaterialTheme.komoTypography.label,
                 modifier = Modifier.padding(top = 4.dp)
             )
@@ -264,7 +266,8 @@ fun Select(
     enabled: Boolean = true,
     placeholder: String = "Select option...",
     isError: Boolean = false,
-    supportingText: String? = null
+    supportingText: String? = null,
+    colors: FieldColors = KomoFieldDefaults.colors()
 ) {
     Select(
         options = options,
@@ -275,6 +278,7 @@ fun Select(
         enabled = enabled,
         placeholder = placeholder,
         isError = isError,
-        supportingText = supportingText
+        supportingText = supportingText,
+        colors = colors
     )
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -145,7 +145,7 @@ fun <T> Select(
                 Text(
                     text = displayText ?: placeholder,
                     color = if (displayText != null) styles.foreground else styles.mutedForeground,
-                    fontSize = 14.sp,
+                    style = MaterialTheme.komoTypography.body,
                     modifier = Modifier.weight(1f)
                 )
                 Icon(
@@ -220,7 +220,7 @@ fun <T> Select(
                                         Text(
                                             text = label(option),
                                             color = optionTextColor,
-                                            fontSize = 14.sp,
+                                            style = MaterialTheme.komoTypography.body,
                                             modifier = Modifier.weight(1f)
                                         )
                                         if (isSelected) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.KomoFieldDefaults
 import com.komoui.themes.styles
+import com.komoui.themes.komoTypography
 import com.komoui.utils.komoClickable
 import com.komoui.utils.rememberAnchoredPopupPositionProvider
 
@@ -80,7 +81,9 @@ fun <T> Select(
     label: (T) -> String,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    placeholder: String = "Select option..."
+    placeholder: String = "Select option...",
+    isError: Boolean = false,
+    supportingText: String? = null
 ) {
     val styles = MaterialTheme.styles
     val radius = MaterialTheme.radius
@@ -96,7 +99,11 @@ fun <T> Select(
     val isPressed by interactionSource.collectIsPressedAsState()
 
     val currentBorderColor by animateColorAsState(
-        targetValue = if (enabled && (isFocused || isPressed || expanded)) styles.ring else styles.border,
+        targetValue = when {
+            isError -> styles.destructive
+            enabled && (isFocused || isPressed || expanded) -> styles.ring
+            else -> styles.border
+        },
         animationSpec = tween(150), label = "selectBorderColor"
     )
 
@@ -150,6 +157,15 @@ fun <T> Select(
                         .graphicsLayer { rotationZ = arrowRotation }
                 )
             }
+        }
+
+        if (supportingText != null) {
+            Text(
+                text = supportingText,
+                color = if (isError) styles.destructive else styles.mutedForeground,
+                style = MaterialTheme.komoTypography.label,
+                modifier = Modifier.padding(top = 4.dp)
+            )
         }
 
         // Dropdown Popup
@@ -246,7 +262,9 @@ fun Select(
     onOptionSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    placeholder: String = "Select option..."
+    placeholder: String = "Select option...",
+    isError: Boolean = false,
+    supportingText: String? = null
 ) {
     Select(
         options = options,
@@ -255,6 +273,8 @@ fun Select(
         label = { it },
         modifier = modifier,
         enabled = enabled,
-        placeholder = placeholder
+        placeholder = placeholder,
+        isError = isError,
+        supportingText = supportingText
     )
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Select.kt
@@ -45,10 +45,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
@@ -56,7 +54,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
-import kotlin.math.roundToInt
+import com.komoui.utils.rememberAnchoredPopupPositionProvider
 
 /**
  * A Jetpack Compose Select component for KomoUI.
@@ -87,13 +85,10 @@ fun <T> Select(
     val radius = MaterialTheme.radius
     var expanded by remember { mutableStateOf(false) }
 
-    // State to hold the position and width of the input field
+    // Width of the trigger, so the popup can match it. Position/flipping is handled by the provider.
     var inputWidthPx by remember { mutableIntStateOf(0) }
-    var inputHeightPx by remember { mutableIntStateOf(0) }
-    var inputXPositionPx by remember { mutableIntStateOf(0) }
-    var inputYPositionPx by remember { mutableIntStateOf(0) }
-
     val density = LocalDensity.current
+    val positionProvider = rememberAnchoredPopupPositionProvider()
 
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -118,12 +113,7 @@ fun <T> Select(
                 .fillMaxWidth()
                 .height(48.dp)
                 .onGloballyPositioned { coordinates ->
-                    // Get the size and position of the input field
                     inputWidthPx = coordinates.size.width
-                    inputHeightPx = coordinates.size.height
-                    val position = coordinates.parentLayoutCoordinates?.windowToLocal(coordinates.positionInWindow())
-                    inputXPositionPx = position?.x?.roundToInt() ?: 0
-                    inputYPositionPx = position?.y?.roundToInt() ?: 0
                 }
                 .border(1.dp, currentBorderColor, RoundedCornerShape(radius.md))
                 .clip(RoundedCornerShape(radius.md))
@@ -164,8 +154,7 @@ fun <T> Select(
         // Dropdown Popup
         if (expanded) {
             Popup(
-                // Position the popup relative to the input field
-                offset = IntOffset(inputXPositionPx, inputYPositionPx + inputHeightPx),
+                popupPositionProvider = positionProvider,
                 properties = PopupProperties(focusable = true), // Make popup focusable to handle outside clicks
                 onDismissRequest = { expanded = false }
             ) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Slider.kt
@@ -10,16 +10,19 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SliderColors
 import androidx.compose.material3.Slider as ComposeSlider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.komoui.themes.KomoStyles
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
+/**
+ * @param colors The [SliderStyle] resolving the slider's colors. See [SliderDefaults.colors].
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Slider(
@@ -29,9 +32,8 @@ fun Slider(
     valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
     steps: Int = 0,
     enabled: Boolean = true,
-    colors: SliderColors? = null
+    colors: SliderStyle = SliderDefaults.colors()
 ) {
-    val themeColors = MaterialTheme.styles
     val radius = MaterialTheme.radius
     ComposeSlider(
         value = value,
@@ -43,27 +45,19 @@ fun Slider(
         valueRange = valueRange,
         steps = steps,
         enabled = enabled,
-        colors = colors ?: SliderDefaults.colors(
-            thumbColor = themeColors.background,
-            activeTrackColor = themeColors.primary,
-            inactiveTrackColor = themeColors.secondary,
-            disabledThumbColor = themeColors.mutedForeground.copy(alpha = 0.5f),
-            disabledActiveTrackColor = themeColors.primary.copy(alpha = 0.5f),
-            disabledInactiveTrackColor = themeColors.secondary.copy(alpha = 0.5f)
-        ),
         thumb = {
-            val borderColor = if (enabled) themeColors.primary else themeColors.primary.copy(alpha = 0.5f)
+            val borderColor = if (enabled) colors.thumbBorder else colors.thumbBorder.copy(alpha = 0.5f)
             Box(
                 modifier = Modifier
                     .size(20.dp)
                     .clip(CircleShape)
-                    .background(themeColors.background)
+                    .background(colors.thumb)
                     .border(2.dp, borderColor, CircleShape)
             )
         },
         track = {
-            val trackColor = if (enabled) themeColors.secondary else themeColors.secondary.copy(alpha = 0.5f)
-            val activeTrackColor = if (enabled) themeColors.primary else themeColors.primary.copy(alpha = 0.5f)
+            val trackColor = if (enabled) colors.track else colors.track.copy(alpha = 0.5f)
+            val activeTrackColor = if (enabled) colors.activeTrack else colors.activeTrack.copy(alpha = 0.5f)
             // Fraction of the active track; guard the empty range and clamp out-of-range values,
             // since fillMaxWidth() requires a 0..1 fraction.
             val span = valueRange.endInclusive - valueRange.start
@@ -86,4 +80,30 @@ fun Slider(
             }
         }
     )
+}
+
+/** Colors used by a [Slider]. Disabled states are derived at 50% alpha. */
+data class SliderStyle(
+    val thumb: Color,
+    val thumbBorder: Color,
+    val track: Color,
+    val activeTrack: Color,
+)
+
+object SliderDefaults {
+    private fun colorsFrom(styles: KomoStyles): SliderStyle = SliderStyle(
+        thumb = styles.background,
+        thumbBorder = styles.primary,
+        track = styles.secondary,
+        activeTrack = styles.primary,
+    )
+
+    /** [SliderStyle] with the default KomoUI color scheme. */
+    @Composable
+    fun colors(): SliderStyle = colorsFrom(MaterialTheme.styles)
+
+    /** [SliderStyle] with the default scheme, mutated by [overrides]. */
+    @Composable
+    fun colors(overrides: SliderStyle.() -> SliderStyle): SliderStyle =
+        colorsFrom(MaterialTheme.styles).overrides()
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Switch.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import com.komoui.themes.KomoStyles
 import com.komoui.themes.styles
 import com.komoui.utils.komoToggleable
 
@@ -132,9 +133,7 @@ data class SwitchStyle(
 )
 
 object SwitchDefaults {
-    @Composable
-    fun colors(): SwitchStyle {
-        val styles = MaterialTheme.styles
+    private fun colorsFrom(styles: KomoStyles): SwitchStyle {
         return SwitchStyle(
             checkedBorder = styles.primary,
             checkedTrack = styles.primary,
@@ -144,4 +143,11 @@ object SwitchDefaults {
             uncheckedThumb = styles.primary
         )
     }
+
+    @Composable
+    fun colors(): SwitchStyle = colorsFrom(MaterialTheme.styles)
+
+    @Composable
+    fun colors(overrides: SwitchStyle.() -> SwitchStyle): SwitchStyle =
+        colorsFrom(MaterialTheme.styles).overrides()
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Table.kt
@@ -331,7 +331,10 @@ fun PaginationScope.DefaultPagination() {
  * @param enableSelection When true a leading checkbox column is auto-prepended.
  * @param selectionColumnWidth Width of the auto-injected selection column.
  * @param pageSize Rows per page.
- * @param initialSort Initial sort state.
+ * @param initialSort Initial sort state in uncontrolled mode.
+ * @param sort Controlled sort state. Pass non-null (with [onSortChange]) to drive sorting externally.
+ * @param selectedKeys Controlled selection as a set of [rowKey] values. Pass non-null (with
+ *      [onSelectionChange]) to drive selection externally, e.g. to clear it programmatically.
  * @param onSortChange Observer callback fired when sort changes.
  * @param onSelectionChange Observer callback fired when selection changes. Emits the set of
  *      selected [rowKey] values, so selection survives item-instance refreshes and never
@@ -357,6 +360,8 @@ fun <T> DataTable(
     selectionColumnWidth: Dp = 48.dp,
     pageSize: Int = 10,
     initialSort: SortState = SortState(),
+    sort: SortState? = null,
+    selectedKeys: Set<Any>? = null,
     onSortChange: ((SortState) -> Unit)? = null,
     onSelectionChange: ((Set<Any>) -> Unit)? = null,
     onRowClick: ((T) -> Unit)? = null,
@@ -365,26 +370,29 @@ fun <T> DataTable(
 ) {
     val styles = MaterialTheme.styles
 
-    var sort by remember { mutableStateOf(initialSort) }
+    // Controlled ([sort] non-null) or uncontrolled (seeded by [initialSort]) sort state.
+    var internalSort by remember { mutableStateOf(initialSort) }
+    val effectiveSort = sort ?: internalSort
     val updateSort: (SortState) -> Unit = { next ->
-        sort = next
+        if (sort == null) internalSort = next
         onSortChange?.invoke(next)
     }
 
-    // Selection is stored by rowKey, not item instance, so it survives item refreshes
-    // and can never hold two entries for the same row.
-    var selectedKeySet by remember { mutableStateOf<Set<Any>>(emptySet()) }
+    // Selection is stored by rowKey, not item instance, so it survives item refreshes and can
+    // never hold two entries for the same row. Controlled via [selectedKeys], else internal.
+    var internalSelection by remember { mutableStateOf<Set<Any>>(emptySet()) }
+    val selectedKeySet = selectedKeys ?: internalSelection
     val updateSelection: (Set<Any>) -> Unit = { next ->
-        selectedKeySet = next
+        if (selectedKeys == null) internalSelection = next
         onSelectionChange?.invoke(next)
     }
 
-    val sorted = remember(items, sort, columns) {
-        val col = columns.firstOrNull { it.id == sort.columnId }
+    val sorted = remember(items, effectiveSort, columns) {
+        val col = columns.firstOrNull { it.id == effectiveSort.columnId }
         val cmp = col?.comparator
         when {
-            cmp == null || sort.direction == SortDirection.NONE -> items
-            sort.direction == SortDirection.ASC -> items.sortedWith(cmp)
+            cmp == null || effectiveSort.direction == SortDirection.NONE -> items
+            effectiveSort.direction == SortDirection.ASC -> items.sortedWith(cmp)
             else -> items.sortedWith(cmp.reversed())
         }
     }
@@ -454,10 +462,10 @@ fun <T> DataTable(
                         ) {
                             SortableHeader(
                                 column = col,
-                                sort = sort,
+                                sort = effectiveSort,
                                 onClick = {
                                     if (col.sortable && col.comparator != null) {
-                                        updateSort(nextSort(sort, col.id))
+                                        updateSort(nextSort(effectiveSort, col.id))
                                     }
                                 }
                             )

--- a/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/Tabs.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoSelectable
 
@@ -137,8 +138,8 @@ fun TabsTrigger(
         Text(
             text = text,
             color = textColor,
-            fontSize = 14.sp,
-            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+            style = if (isSelected) MaterialTheme.komoTypography.bodyMedium
+            else MaterialTheme.komoTypography.body
         )
     }
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/AreaChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/AreaChart.kt
@@ -1,43 +1,17 @@
 package com.komoui.components.charts
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.komoui.themes.styles
-import kotlin.math.max
 
 /**
  * Area chart supporting one or more series. Each series renders as a stroked
@@ -49,11 +23,7 @@ import kotlin.math.max
  *
  * When [scrollable] is true the plot area scrolls horizontally and each
  * x-category is given at least [minColumnWidth] of space. The y-axis labels
- * stay pinned on the left. Drag-scrub tooltips are force-disabled in this
- * mode: `chartScrub` claims the gesture on pointer-down while
- * `Modifier.horizontalScroll` claims after touch-slop, so they can't coexist
- * without changing one strategy (see `Chart.md` in this directory, Pitfall #4,
- * for the long-press / tap-only alternatives).
+ * stay pinned on the left. Drag-scrub tooltips are force-disabled in this mode.
  *
  * Lines reveal left to right on first composition when [animate] is true.
  */
@@ -73,219 +43,75 @@ fun AreaChart(
     scrollable: Boolean = false,
     minColumnWidth: Dp = 56.dp,
 ) {
-    val textMeasurer = rememberTextMeasurer()
-    val labelStyle = chartLabelStyle()
-    val gridColor = MaterialTheme.styles.border
-    val labelColor = MaterialTheme.styles.mutedForeground
-    val indicatorColor = MaterialTheme.styles.mutedForeground
-    val dotInnerColor = MaterialTheme.styles.popover
-
-    val xLabels = series.firstOrNull()?.points?.map { it.x } ?: emptyList()
-    val columnCount = xLabels.size
-
-    val allValues = series.flatMap { s -> s.points.map { it.y } }
-    val minValue = allValues.minOrNull() ?: 0f
-    val maxValue = allValues.maxOrNull() ?: 1f
-    val domain = computeDomain(minValue, maxValue, axisOptions.yDomain)
-    val ticks = yTicks(domain, axisOptions.yTickCount)
-
     val density = LocalDensity.current
-    val insets = AxisInsetsDp()
-    val yAxisWidthDp = if (axisOptions.showY) insets.left else 0.dp
-    val bottomInsetPx = with(density) { (if (axisOptions.showX) insets.bottom else 0.dp).toPx() }
     val strokePx = with(density) { strokeWidth.toPx() }
     val dotPx = with(density) { 3.dp.toPx() }
+    val dotInnerColor = MaterialTheme.styles.popover
 
-    val progress = remember { Animatable(if (animate) 0f else 1f) }
-    LaunchedEffect(series) {
-        if (animate) {
-            progress.snapTo(0f)
-            progress.animateTo(1f, tween(durationMillis = 800))
-        } else {
-            progress.snapTo(1f)
-        }
-    }
+    ChartScaffold(
+        series = series,
+        modifier = modifier,
+        axisOptions = axisOptions,
+        showTooltip = showTooltip,
+        showLegend = showLegend,
+        chartHeight = chartHeight,
+        scrollable = scrollable,
+        minColumnWidth = minColumnWidth,
+        animate = animate,
+        animationDurationMillis = 800,
+    ) { scope ->
+        val plotRect = scope.plotRect
+        val slotWidth = scope.slotWidth
+        val baselineY = plotRect.bottom - ((0f - scope.domain.start) / scope.span) * plotRect.height
+        val clipRight = plotRect.left + plotRect.width * scope.progress
 
-    val scrub = rememberChartScrubState()
-    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-    val effectiveShowTooltip = showTooltip && !scrollable
-    val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
+        clipRect(left = 0f, top = 0f, right = clipRight, bottom = size.height) {
+            series.forEach { s ->
+                // Clamp to the shared column count so a longer series doesn't draw past the plot.
+                val points = seriesPositions(
+                    s.points.take(scope.columnCount).map { it.y }, plotRect, scope.domain, slotWidth,
+                )
+                if (points.isEmpty()) return@forEach
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .semantics(mergeDescendants = true) {
-                contentDescription =
-                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
-            }
-    ) {
-        Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
-            if (axisOptions.showY) {
-                Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {
-                    val yAxisRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-                    drawYAxisOnly(
-                        yAxisRect = yAxisRect,
-                        yTicks = ticks,
-                        domain = domain,
-                        yLabelFormatter = axisOptions.yLabelFormatter,
-                        textMeasurer = textMeasurer,
-                        labelStyle = labelStyle,
-                        labelColor = labelColor,
+                val linePath = buildLinePath(points, smooth)
+                val areaPath = Path().apply {
+                    addPath(linePath)
+                    lineTo(points.last().x, baselineY)
+                    lineTo(points.first().x, baselineY)
+                    close()
+                }
+
+                val brush = if (gradientFill) {
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            s.color.copy(alpha = 0.40f),
+                            s.color.copy(alpha = 0.0f),
+                        ),
+                        startY = plotRect.top,
+                        endY = baselineY,
+                    )
+                } else {
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            s.color.copy(alpha = fillAlpha),
+                            s.color.copy(alpha = fillAlpha),
+                        ),
                     )
                 }
-            }
 
-            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxHeight()) {
-                val viewportDp = maxWidth
-                val rawContentDp = if (columnCount > 0) minColumnWidth * columnCount else viewportDp
-                val contentWidthDp =
-                    if (scrollable) maxOf(rawContentDp, viewportDp) else viewportDp
-                val needsScroll = scrollable && contentWidthDp > viewportDp
-
-                val scrollMod = if (needsScroll) {
-                    Modifier.horizontalScroll(rememberScrollState())
-                } else Modifier
-
-                Box(modifier = Modifier.fillMaxSize().then(scrollMod)) {
-                    val gestureMod = if (effectiveShowTooltip && columnCount > 0) {
-                        Modifier.chartScrub(
-                            columnCount = columnCount,
-                            plotLeft = 0f,
-                            plotWidth = canvasSize.width.toFloat(),
-                        ) { idx, pos ->
-                            scrub.index = idx
-                            scrub.pointer = pos
-                        }
-                    } else Modifier
-
-                    Canvas(
-                        modifier = Modifier
-                            .width(contentWidthDp)
-                            .fillMaxHeight()
-                            .onSizeChanged { canvasSize = it }
-                            .then(gestureMod),
-                    ) {
-                        val plotRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-
-                        drawAxesAndGrid(
-                            plotRect = plotRect,
-                            xLabels = xLabels,
-                            yTicks = ticks,
-                            domain = domain,
-                            axisOptions = plotAxisOptions,
-                            textMeasurer = textMeasurer,
-                            labelStyle = labelStyle,
-                            gridColor = gridColor,
-                            labelColor = labelColor,
-                        )
-
-                        if (columnCount == 0 || series.isEmpty()) return@Canvas
-
-                        val span = domain.endInclusive - domain.start
-                        if (span <= 0f) return@Canvas
-
-                        val slotWidth = plotRect.width / columnCount
-                        val baselineY = plotRect.bottom -
-                            ((0f - domain.start) / span) * plotRect.height
-                        val clipRight = plotRect.left + plotRect.width * progress.value
-
-                        clipRect(
-                            left = 0f,
-                            top = 0f,
-                            right = clipRight,
-                            bottom = size.height,
-                        ) {
-                            series.forEach { s ->
-                                val points = seriesPositions(
-                                    s.points.map { it.y }, plotRect, domain, slotWidth,
-                                )
-                                if (points.isEmpty()) return@forEach
-
-                                val linePath = buildLinePath(points, smooth)
-
-                                val areaPath = Path().apply {
-                                    addPath(linePath)
-                                    lineTo(points.last().x, baselineY)
-                                    lineTo(points.first().x, baselineY)
-                                    close()
-                                }
-
-                                val brush = if (gradientFill) {
-                                    Brush.verticalGradient(
-                                        colors = listOf(
-                                            s.color.copy(alpha = 0.40f),
-                                            s.color.copy(alpha = 0.0f),
-                                        ),
-                                        startY = plotRect.top,
-                                        endY = baselineY,
-                                    )
-                                } else {
-                                    Brush.verticalGradient(
-                                        colors = listOf(
-                                            s.color.copy(alpha = fillAlpha),
-                                            s.color.copy(alpha = fillAlpha),
-                                        ),
-                                    )
-                                }
-
-                                drawPath(path = areaPath, brush = brush)
-                                drawPath(
-                                    path = linePath,
-                                    color = s.color,
-                                    style = Stroke(width = strokePx),
-                                )
-                            }
-                        }
-
-                        scrub.index?.let { idx ->
-                            drawScrubIndicator(plotRect, columnCount, idx, indicatorColor)
-                            series.forEach { s ->
-                                val p = s.points.getOrNull(idx) ?: return@forEach
-                                val cx = plotRect.left + slotWidth * (idx + 0.5f)
-                                val cy = plotRect.bottom -
-                                    ((p.y - domain.start) / span) * plotRect.height
-                                drawCircle(
-                                    color = s.color,
-                                    radius = dotPx + 1.5f,
-                                    center = Offset(cx, cy),
-                                )
-                                drawCircle(
-                                    color = dotInnerColor,
-                                    radius = dotPx,
-                                    center = Offset(cx, cy),
-                                )
-                            }
-                        }
-                    }
-
-                    val activeIdx = scrub.index
-                    if (effectiveShowTooltip &&
-                        activeIdx != null && activeIdx in 0 until columnCount
-                    ) {
-                        val slotWidthPx = canvasSize.width.toFloat() / columnCount
-                        val centerX = slotWidthPx * (activeIdx + 0.5f)
-                        val xDp = with(density) { centerX.toDp() }
-                        Box(modifier = Modifier.padding(start = xDp + 8.dp, top = 8.dp)) {
-                            ChartTooltip(
-                                title = xLabels.getOrNull(activeIdx).orEmpty(),
-                                entries = series.mapNotNull { s ->
-                                    val p = s.points.getOrNull(activeIdx)
-                                        ?: return@mapNotNull null
-                                    TooltipEntry(
-                                        label = s.label,
-                                        value = axisOptions.yLabelFormatter(p.y),
-                                        color = s.color,
-                                    )
-                                },
-                            )
-                        }
-                    }
-                }
+                drawPath(path = areaPath, brush = brush)
+                drawPath(path = linePath, color = s.color, style = Stroke(width = strokePx))
             }
         }
 
-        if (showLegend) {
-            ChartLegend(items = series.map { it.label to it.color })
+        scope.scrubIndex?.let { idx ->
+            series.forEach { s ->
+                val p = s.points.getOrNull(idx) ?: return@forEach
+                val cx = plotRect.left + slotWidth * (idx + 0.5f)
+                val cy = plotRect.bottom - ((p.y - scope.domain.start) / scope.span) * plotRect.height
+                drawCircle(color = s.color, radius = dotPx + 1.5f, center = Offset(cx, cy))
+                drawCircle(color = dotInnerColor, radius = dotPx, center = Offset(cx, cy))
+            }
         }
     }
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/BarChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/BarChart.kt
@@ -1,39 +1,15 @@
 package com.komoui.components.charts
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.komoui.themes.styles
 import kotlin.math.max
@@ -45,17 +21,13 @@ import kotlin.math.min
  * Each series in [series] is expected to share the same x-categories with the
  * first series; categories beyond the first series' point list are ignored.
  * When [showValueLabels] is true the y-value is drawn just above each bar.
- * When [showTooltip] is true (and [scrollable] is false), press-and-drag
- * horizontally to scrub through categories — a tooltip appears with all
- * series values for the active column.
+ * When [showTooltip] is true (and [scrollable] is false), drag horizontally to
+ * scrub through categories — a tooltip appears with all series values for the
+ * active column.
  *
  * When [scrollable] is true the plot area scrolls horizontally and each
  * x-category is given at least [minColumnWidth] of space. The y-axis labels
- * stay pinned on the left. Drag-scrub tooltips are force-disabled in this
- * mode: `chartScrub` claims the gesture on pointer-down while
- * `Modifier.horizontalScroll` claims after touch-slop, so they can't coexist
- * without changing one strategy (see `Chart.md` in this directory, Pitfall #4,
- * for the long-press / tap-only alternatives).
+ * stay pinned on the left. Drag-scrub tooltips are force-disabled in this mode.
  *
  * Bars animate from height 0 to their final height on first composition when
  * [animate] is true.
@@ -75,193 +47,61 @@ fun BarChart(
     scrollable: Boolean = false,
     minColumnWidth: Dp = 56.dp,
 ) {
+    val density = LocalDensity.current
+    val cornerPx = with(density) { barCornerRadius.toPx() }
     val textMeasurer = rememberTextMeasurer()
     val labelStyle = chartLabelStyle()
-    val gridColor = MaterialTheme.styles.border
     val labelColor = MaterialTheme.styles.mutedForeground
-    val indicatorColor = MaterialTheme.styles.mutedForeground
 
-    val xLabels = series.firstOrNull()?.points?.map { it.x } ?: emptyList()
-    val columnCount = xLabels.size
+    ChartScaffold(
+        series = series,
+        modifier = modifier,
+        axisOptions = axisOptions,
+        showTooltip = showTooltip,
+        showLegend = showLegend,
+        chartHeight = chartHeight,
+        scrollable = scrollable,
+        minColumnWidth = minColumnWidth,
+        animate = animate,
+        animationDurationMillis = 600,
+    ) { scope ->
+        val plotRect = scope.plotRect
+        val span = scope.span
+        val growth = scope.progress
+        val baselineY = plotRect.bottom - ((0f - scope.domain.start) / span) * plotRect.height
+        val groupWidth = scope.slotWidth * barWidthFraction
+        val barWidth = groupWidth / series.size
 
-    val allValues = series.flatMap { s -> s.points.map { it.y } }
-    val minValue = allValues.minOrNull() ?: 0f
-    val maxValue = allValues.maxOrNull() ?: 1f
-    val domain = computeDomain(minValue, maxValue, axisOptions.yDomain)
-    val ticks = yTicks(domain, axisOptions.yTickCount)
+        for (col in 0 until scope.columnCount) {
+            val slotCenter = plotRect.left + scope.slotWidth * (col + 0.5f)
+            val groupLeft = slotCenter - groupWidth / 2f
+            series.forEachIndexed { si, s ->
+                val point = s.points.getOrNull(col) ?: return@forEachIndexed
+                val targetY = plotRect.bottom - ((point.y - scope.domain.start) / span) * plotRect.height
+                val animatedTop = baselineY + (targetY - baselineY) * growth
+                val barLeft = groupLeft + si * barWidth
+                val top = min(animatedTop, baselineY)
+                val bottom = max(animatedTop, baselineY)
+                drawRoundRect(
+                    color = s.color,
+                    topLeft = Offset(barLeft + barWidth * 0.08f, top),
+                    size = Size(width = barWidth * 0.84f, height = max(0f, bottom - top)),
+                    cornerRadius = CornerRadius(cornerPx, cornerPx),
+                )
 
-    val density = LocalDensity.current
-    val insets = AxisInsetsDp()
-    val yAxisWidthDp = if (axisOptions.showY) insets.left else 0.dp
-    val bottomInsetPx = with(density) { (if (axisOptions.showX) insets.bottom else 0.dp).toPx() }
-    val cornerPx = with(density) { barCornerRadius.toPx() }
-
-    val growth = remember { Animatable(if (animate) 0f else 1f) }
-    LaunchedEffect(series) {
-        if (animate) {
-            growth.snapTo(0f)
-            growth.animateTo(1f, tween(durationMillis = 600))
-        } else {
-            growth.snapTo(1f)
-        }
-    }
-
-    val scrub = rememberChartScrubState()
-    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-    val effectiveShowTooltip = showTooltip && !scrollable
-    val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
-
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .semantics(mergeDescendants = true) {
-                contentDescription =
-                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
-            }
-    ) {
-        Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
-            // Pinned y-axis canvas
-            if (axisOptions.showY) {
-                Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {
-                    val yAxisRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-                    drawYAxisOnly(
-                        yAxisRect = yAxisRect,
-                        yTicks = ticks,
-                        domain = domain,
-                        yLabelFormatter = axisOptions.yLabelFormatter,
-                        textMeasurer = textMeasurer,
-                        labelStyle = labelStyle,
-                        labelColor = labelColor,
+                if (showValueLabels && growth >= 1f) {
+                    val labelText = axisOptions.yLabelFormatter(point.y)
+                    val measured = textMeasurer.measure(labelText, labelStyle)
+                    drawText(
+                        textLayoutResult = measured,
+                        color = labelColor,
+                        topLeft = Offset(
+                            x = barLeft + barWidth / 2f - measured.size.width / 2f,
+                            y = top - measured.size.height - 4f,
+                        ),
                     )
                 }
             }
-
-            // Plot area (optionally scrollable)
-            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxHeight()) {
-                val viewportDp = maxWidth
-                val rawContentDp = if (columnCount > 0) minColumnWidth * columnCount else viewportDp
-                val contentWidthDp =
-                    if (scrollable) maxOf(rawContentDp, viewportDp) else viewportDp
-                val needsScroll = scrollable && contentWidthDp > viewportDp
-
-                val scrollMod = if (needsScroll) {
-                    Modifier.horizontalScroll(rememberScrollState())
-                } else Modifier
-
-                Box(modifier = Modifier.fillMaxSize().then(scrollMod)) {
-                    val gestureMod = if (effectiveShowTooltip && columnCount > 0) {
-                        Modifier.chartScrub(
-                            columnCount = columnCount,
-                            plotLeft = 0f,
-                            plotWidth = canvasSize.width.toFloat(),
-                        ) { idx, pos ->
-                            scrub.index = idx
-                            scrub.pointer = pos
-                        }
-                    } else Modifier
-
-                    Canvas(
-                        modifier = Modifier
-                            .width(contentWidthDp)
-                            .fillMaxHeight()
-                            .onSizeChanged { canvasSize = it }
-                            .then(gestureMod),
-                    ) {
-                        val plotRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-
-                        drawAxesAndGrid(
-                            plotRect = plotRect,
-                            xLabels = xLabels,
-                            yTicks = ticks,
-                            domain = domain,
-                            axisOptions = plotAxisOptions,
-                            textMeasurer = textMeasurer,
-                            labelStyle = labelStyle,
-                            gridColor = gridColor,
-                            labelColor = labelColor,
-                        )
-
-                        if (columnCount == 0 || series.isEmpty()) return@Canvas
-
-                        val span = domain.endInclusive - domain.start
-                        if (span <= 0f) return@Canvas
-
-                        val baselineY = plotRect.bottom -
-                            ((0f - domain.start) / span) * plotRect.height
-                        val slotWidth = plotRect.width / columnCount
-                        val groupWidth = slotWidth * barWidthFraction
-                        val barWidth = groupWidth / series.size
-
-                        for (col in 0 until columnCount) {
-                            val slotCenter = plotRect.left + slotWidth * (col + 0.5f)
-                            val groupLeft = slotCenter - groupWidth / 2f
-                            series.forEachIndexed { si, s ->
-                                val point = s.points.getOrNull(col) ?: return@forEachIndexed
-                                val targetY = plotRect.bottom -
-                                    ((point.y - domain.start) / span) * plotRect.height
-                                val animatedTop = baselineY + (targetY - baselineY) * growth.value
-                                val barLeft = groupLeft + si * barWidth
-                                val top = min(animatedTop, baselineY)
-                                val bottom = max(animatedTop, baselineY)
-                                drawRoundRect(
-                                    color = s.color,
-                                    topLeft = Offset(barLeft + barWidth * 0.08f, top),
-                                    size = Size(
-                                        width = barWidth * 0.84f,
-                                        height = max(0f, bottom - top),
-                                    ),
-                                    cornerRadius = CornerRadius(cornerPx, cornerPx),
-                                )
-
-                                if (showValueLabels && growth.value >= 1f) {
-                                    val labelText = axisOptions.yLabelFormatter(point.y)
-                                    val measured = textMeasurer.measure(labelText, labelStyle)
-                                    drawText(
-                                        textLayoutResult = measured,
-                                        color = labelColor,
-                                        topLeft = Offset(
-                                            x = barLeft + barWidth / 2f -
-                                                measured.size.width / 2f,
-                                            y = top - measured.size.height - 4f,
-                                        ),
-                                    )
-                                }
-                            }
-                        }
-
-                        scrub.index?.let { idx ->
-                            drawScrubIndicator(plotRect, columnCount, idx, indicatorColor)
-                        }
-                    }
-
-                    val activeIdx = scrub.index
-                    if (effectiveShowTooltip &&
-                        activeIdx != null && activeIdx in 0 until columnCount
-                    ) {
-                        val slotWidthPx = canvasSize.width.toFloat() / columnCount
-                        val centerX = slotWidthPx * (activeIdx + 0.5f)
-                        val xDp = with(density) { centerX.toDp() }
-                        Box(modifier = Modifier.padding(start = xDp + 8.dp, top = 8.dp)) {
-                            ChartTooltip(
-                                title = xLabels.getOrNull(activeIdx).orEmpty(),
-                                entries = series.mapNotNull { s ->
-                                    val p = s.points.getOrNull(activeIdx)
-                                        ?: return@mapNotNull null
-                                    TooltipEntry(
-                                        label = s.label,
-                                        value = axisOptions.yLabelFormatter(p.y),
-                                        color = s.color,
-                                    )
-                                },
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        if (showLegend) {
-            ChartLegend(items = series.map { it.label to it.color })
         }
     }
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
@@ -276,7 +276,9 @@ internal fun DrawScope.drawAxesAndGrid(
     val span = domain.endInclusive - domain.start
     if (span <= 0f) return
 
-    val dashEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f))
+    val strokePx = 1.dp.toPx()
+    val gap4 = 4.dp.toPx()
+    val dashEffect = PathEffect.dashPathEffect(floatArrayOf(gap4, gap4))
 
     if (axisOptions.showHorizontalGrid) {
         yTicks.forEach { tick ->
@@ -285,7 +287,7 @@ internal fun DrawScope.drawAxesAndGrid(
                 color = gridColor,
                 start = Offset(plotRect.left, y),
                 end = Offset(plotRect.right, y),
-                strokeWidth = 1f,
+                strokeWidth = strokePx,
                 pathEffect = if (tick == domain.start) null else dashEffect,
             )
         }
@@ -299,7 +301,7 @@ internal fun DrawScope.drawAxesAndGrid(
                 color = gridColor,
                 start = Offset(x, plotRect.top),
                 end = Offset(x, plotRect.bottom),
-                strokeWidth = 1f,
+                strokeWidth = strokePx,
                 pathEffect = dashEffect,
             )
         }
@@ -314,7 +316,7 @@ internal fun DrawScope.drawAxesAndGrid(
                 textLayoutResult = measured,
                 color = labelColor,
                 topLeft = Offset(
-                    x = plotRect.left - measured.size.width - 4f,
+                    x = plotRect.left - measured.size.width - 4.dp.toPx(),
                     y = y - measured.size.height / 2f,
                 ),
             )
@@ -332,7 +334,7 @@ internal fun DrawScope.drawAxesAndGrid(
                 color = labelColor,
                 topLeft = Offset(
                     x = centerX - measured.size.width / 2f,
-                    y = plotRect.bottom + 6f,
+                    y = plotRect.bottom + 6.dp.toPx(),
                 ),
             )
         }
@@ -367,7 +369,7 @@ internal fun DrawScope.drawYAxisOnly(
             textLayoutResult = measured,
             color = labelColor,
             topLeft = Offset(
-                x = yAxisRect.right - measured.size.width - 4f,
+                x = yAxisRect.right - measured.size.width - 4.dp.toPx(),
                 y = y - measured.size.height / 2f,
             ),
         )
@@ -386,12 +388,13 @@ internal fun DrawScope.drawScrubIndicator(
     if (columnCount <= 0) return
     val slot = plotRect.width / columnCount
     val x = plotRect.left + slot * (activeIndex + 0.5f)
+    val dash = 3.dp.toPx()
     drawLine(
         color = color,
         start = Offset(x, plotRect.top),
         end = Offset(x, plotRect.bottom),
-        strokeWidth = 1f,
-        pathEffect = PathEffect.dashPathEffect(floatArrayOf(3f, 3f)),
+        strokeWidth = 1.dp.toPx(),
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(dash, dash)),
     )
 }
 

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/ChartCommon.kt
@@ -1,25 +1,43 @@
 package com.komoui.components.charts
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -28,7 +46,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
@@ -42,7 +61,6 @@ import androidx.compose.ui.unit.sp
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import kotlin.math.abs
-import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.log10
 import kotlin.math.max
@@ -50,61 +68,34 @@ import kotlin.math.min
 import kotlin.math.pow
 
 /**
- * A single bar-chart series.
+ * A single (x-category, y-value) data point shared by all chart types.
+ */
+@Immutable
+data class ChartPoint(val x: String, val y: Float)
+
+/**
+ * A single chart series shared by [BarChart], [LineChart] and [AreaChart].
  *
  * @param key Stable identifier; used for animation keying and tooltip lookup.
  * @param label Human-readable label shown in legend / tooltip.
- * @param color Bar color.
+ * @param color Series color (bar fill / line stroke / area stroke + fill base).
  * @param points Ordered list of (x-category, y-value) points.
  */
 @Immutable
-data class BarSeries(
+data class ChartSeries(
     val key: String,
     val label: String,
     val color: Color,
-    val points: List<BarPoint>,
+    val points: List<ChartPoint>,
 )
 
-@Immutable
-data class BarPoint(val x: String, val y: Float)
-
-/**
- * A single line-chart series.
- *
- * @param key Stable identifier.
- * @param label Human-readable label for legend / tooltip.
- * @param color Stroke color.
- * @param points Ordered list of (x-category, y-value) points.
- */
-@Immutable
-data class LineSeries(
-    val key: String,
-    val label: String,
-    val color: Color,
-    val points: List<LinePoint>,
-)
-
-@Immutable
-data class LinePoint(val x: String, val y: Float)
-
-/**
- * A single area-chart series.
- *
- * @param key Stable identifier.
- * @param label Human-readable label for legend / tooltip.
- * @param color Stroke + fill base color.
- * @param points Ordered list of (x-category, y-value) points.
- */
-@Immutable
-data class AreaSeries(
-    val key: String,
-    val label: String,
-    val color: Color,
-    val points: List<AreaPoint>,
-)
-
-@Immutable
-data class AreaPoint(val x: String, val y: Float)
+// Chart-type-specific aliases kept for source compatibility; all charts share one model.
+typealias BarPoint = ChartPoint
+typealias BarSeries = ChartSeries
+typealias LinePoint = ChartPoint
+typealias LineSeries = ChartSeries
+typealias AreaPoint = ChartPoint
+typealias AreaSeries = ChartSeries
 
 /**
  * Configuration for chart axes and gridlines.
@@ -202,53 +193,46 @@ internal fun computePlotRect(canvasSize: Size, insets: PlotInsets): Rect =
     )
 
 /**
- * Active scrub state for tap-and-drag tooltips. `index = null` means not scrubbing.
+ * Active scrub state for drag tooltips. `index = null` means not scrubbing.
  */
 @Stable
 internal class ChartScrubState {
     var index: Int? by mutableStateOf(null)
-    var pointer: Offset? by mutableStateOf(null)
 }
 
 @Composable
 internal fun rememberChartScrubState(): ChartScrubState = remember { ChartScrubState() }
 
 /**
- * Modifier that attaches tap-and-drag horizontal scrubbing. On press-down the
- * nearest column is selected; the selection follows the finger; release clears.
+ * Modifier that attaches horizontal drag scrubbing: the nearest column is selected once the drag
+ * crosses the horizontal touch slop, the selection follows the finger, and release clears it.
  *
- * This is **claim-on-down**: the first pointer-down is consumed immediately so
- * the tooltip appears under the finger without a touch-slop delay. As a
- * consequence it is **incompatible with `Modifier.horizontalScroll`**, which
- * uses a claim-after-touch-slop strategy — once this modifier consumes the
- * down event the scrollable parent never gets a chance to start scrolling.
- * Chart composables resolve this by disabling tooltips when `scrollable = true`.
- * See `Chart.md` in this directory (Pitfall #4) for alternatives if you need both.
+ * The gesture is claimed only after a **horizontal** drag is detected, so a vertical-scrolling
+ * parent (a chart embedded in a scrollable page — the common case) still receives vertical drags.
+ * It remains incompatible with `Modifier.horizontalScroll` (both want the horizontal slop), which
+ * is why chart composables disable tooltips in `scrollable` mode.
  */
 internal fun Modifier.chartScrub(
     columnCount: Int,
     plotLeft: Float,
     plotWidth: Float,
-    onChange: (Int?, Offset?) -> Unit,
+    onChange: (Int?) -> Unit,
 ): Modifier = this.pointerInput(columnCount, plotLeft, plotWidth) {
     if (columnCount <= 0 || plotWidth <= 0f) return@pointerInput
     awaitPointerEventScope {
         while (true) {
-            val down = awaitPointerEvent()
-            val firstDown = down.changes.firstOrNull { it.pressed && !it.previousPressed } ?: continue
-            firstDown.consume()
-            emitScrub(firstDown.position, columnCount, plotLeft, plotWidth, onChange)
-            var pointerId = firstDown.id
+            val down = awaitFirstDown(requireUnconsumed = false)
+            val dragStart = awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->
+                emitScrub(change.position, columnCount, plotLeft, plotWidth, onChange)
+                change.consume()
+            } ?: continue // cancelled or a vertical drag the parent should handle
+            emitScrub(dragStart.position, columnCount, plotLeft, plotWidth, onChange)
             while (true) {
                 val event = awaitPointerEvent()
-                val change = event.changes.firstOrNull { it.id == pointerId }
-                if (change == null) {
-                    onChange(null, null)
-                    break
-                }
-                if (change.changedToUp()) {
-                    onChange(null, null)
-                    change.consume()
+                val change = event.changes.firstOrNull { it.id == down.id }
+                if (change == null || change.changedToUp()) {
+                    onChange(null)
+                    change?.consume()
                     break
                 }
                 if (change.positionChanged()) {
@@ -265,11 +249,11 @@ private fun emitScrub(
     columnCount: Int,
     plotLeft: Float,
     plotWidth: Float,
-    onChange: (Int?, Offset?) -> Unit,
+    onChange: (Int?) -> Unit,
 ) {
     val rel = ((pos.x - plotLeft) / plotWidth).coerceIn(0f, 1f)
     val idx = (rel * columnCount).toInt().coerceIn(0, columnCount - 1)
-    onChange(idx, pos)
+    onChange(idx)
 }
 
 /**
@@ -426,6 +410,204 @@ internal fun chartSemanticsLabel(seriesLabels: List<String>, pointCount: Int): S
         append(pointCount)
         append(" data points each")
     }
+
+/**
+ * Per-frame plot geometry handed to a chart's draw lambda by [ChartScaffold].
+ *
+ * @property progress Animation progress in `0f..1f` (reveal / grow-in).
+ * @property scrubIndex Active scrub column, or null when not scrubbing.
+ */
+@Immutable
+internal class ChartPlotScope(
+    val plotRect: Rect,
+    val domain: ClosedFloatingPointRange<Float>,
+    val span: Float,
+    val columnCount: Int,
+    val slotWidth: Float,
+    val progress: Float,
+    val scrubIndex: Int?,
+)
+
+/**
+ * Shared chart scaffold behind [BarChart], [LineChart] and [AreaChart]. Owns the pinned y-axis,
+ * horizontal-scroll wiring, drag-scrub gesture, axes/grid, scrub indicator, tooltip and legend;
+ * the caller supplies only [drawPlot], which draws the bars / line / area for one frame.
+ *
+ * Domain and tick computation is remembered on the data (not on the whole [axisOptions], whose
+ * formatter lambdas defeat data-class equality), so scrubbing doesn't recompute them every frame.
+ */
+@Composable
+internal fun ChartScaffold(
+    series: List<ChartSeries>,
+    modifier: Modifier,
+    axisOptions: ChartAxisOptions,
+    showTooltip: Boolean,
+    showLegend: Boolean,
+    chartHeight: Dp,
+    scrollable: Boolean,
+    minColumnWidth: Dp,
+    animate: Boolean,
+    animationDurationMillis: Int,
+    drawPlot: DrawScope.(ChartPlotScope) -> Unit,
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val labelStyle = chartLabelStyle()
+    val gridColor = MaterialTheme.styles.border
+    val labelColor = MaterialTheme.styles.mutedForeground
+    val indicatorColor = MaterialTheme.styles.mutedForeground
+
+    val xLabels = remember(series) { series.firstOrNull()?.points?.map { it.x } ?: emptyList() }
+    val columnCount = xLabels.size
+
+    val domain = remember(series, axisOptions.yDomain) {
+        val allValues = series.flatMap { s -> s.points.map { it.y } }
+        computeDomain(allValues.minOrNull() ?: 0f, allValues.maxOrNull() ?: 1f, axisOptions.yDomain)
+    }
+    val ticks = remember(domain, axisOptions.yTickCount) { yTicks(domain, axisOptions.yTickCount) }
+
+    val density = LocalDensity.current
+    val insets = AxisInsetsDp()
+    val yAxisWidthDp = if (axisOptions.showY) insets.left else 0.dp
+    val bottomInsetPx = with(density) { (if (axisOptions.showX) insets.bottom else 0.dp).toPx() }
+
+    val progress = remember { Animatable(if (animate) 0f else 1f) }
+    LaunchedEffect(series, animate) {
+        if (animate) {
+            progress.snapTo(0f)
+            progress.animateTo(1f, tween(durationMillis = animationDurationMillis))
+        } else {
+            progress.snapTo(1f)
+        }
+    }
+
+    val scrub = rememberChartScrubState()
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    val effectiveShowTooltip = showTooltip && !scrollable
+    val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription =
+                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
+            }
+    ) {
+        Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
+            if (axisOptions.showY) {
+                Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {
+                    val yAxisRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
+                    drawYAxisOnly(
+                        yAxisRect = yAxisRect,
+                        yTicks = ticks,
+                        domain = domain,
+                        yLabelFormatter = axisOptions.yLabelFormatter,
+                        textMeasurer = textMeasurer,
+                        labelStyle = labelStyle,
+                        labelColor = labelColor,
+                    )
+                }
+            }
+
+            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                val viewportDp = maxWidth
+                val rawContentDp = if (columnCount > 0) minColumnWidth * columnCount else viewportDp
+                val contentWidthDp = if (scrollable) maxOf(rawContentDp, viewportDp) else viewportDp
+                val needsScroll = scrollable && contentWidthDp > viewportDp
+
+                val scrollMod = if (needsScroll) {
+                    Modifier.horizontalScroll(rememberScrollState())
+                } else Modifier
+
+                Box(modifier = Modifier.fillMaxSize().then(scrollMod)) {
+                    val gestureMod = if (effectiveShowTooltip && columnCount > 0) {
+                        Modifier.chartScrub(
+                            columnCount = columnCount,
+                            plotLeft = 0f,
+                            plotWidth = canvasSize.width.toFloat(),
+                        ) { idx -> scrub.index = idx }
+                    } else Modifier
+
+                    Canvas(
+                        modifier = Modifier
+                            .width(contentWidthDp)
+                            .fillMaxHeight()
+                            .onSizeChanged { canvasSize = it }
+                            .then(gestureMod),
+                    ) {
+                        val plotRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
+
+                        drawAxesAndGrid(
+                            plotRect = plotRect,
+                            xLabels = xLabels,
+                            yTicks = ticks,
+                            domain = domain,
+                            axisOptions = plotAxisOptions,
+                            textMeasurer = textMeasurer,
+                            labelStyle = labelStyle,
+                            gridColor = gridColor,
+                            labelColor = labelColor,
+                        )
+
+                        if (columnCount == 0 || series.isEmpty()) return@Canvas
+                        val span = domain.endInclusive - domain.start
+                        if (span <= 0f) return@Canvas
+                        val slotWidth = plotRect.width / columnCount
+
+                        drawPlot(
+                            ChartPlotScope(
+                                plotRect = plotRect,
+                                domain = domain,
+                                span = span,
+                                columnCount = columnCount,
+                                slotWidth = slotWidth,
+                                progress = progress.value,
+                                scrubIndex = scrub.index,
+                            )
+                        )
+
+                        scrub.index?.let { idx ->
+                            drawScrubIndicator(plotRect, columnCount, idx, indicatorColor)
+                        }
+                    }
+
+                    val activeIdx = scrub.index
+                    if (effectiveShowTooltip && activeIdx != null && activeIdx in 0 until columnCount) {
+                        val slotWidthPx = canvasSize.width.toFloat() / columnCount
+                        val centerX = slotWidthPx * (activeIdx + 0.5f)
+                        val title = xLabels.getOrNull(activeIdx).orEmpty()
+                        val entries = series.mapNotNull { s ->
+                            val p = s.points.getOrNull(activeIdx) ?: return@mapNotNull null
+                            TooltipEntry(s.label, axisOptions.yLabelFormatter(p.y), s.color)
+                        }
+                        // Flip the tooltip to the left of the scrub line for right-half columns so
+                        // it doesn't clip off the right edge.
+                        if (centerX > canvasSize.width / 2f) {
+                            val endDp = with(density) { (canvasSize.width - centerX).toDp() }
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                                contentAlignment = Alignment.TopEnd,
+                            ) {
+                                Box(modifier = Modifier.padding(end = endDp + 8.dp)) {
+                                    ChartTooltip(title = title, entries = entries)
+                                }
+                            }
+                        } else {
+                            val xDp = with(density) { centerX.toDp() }
+                            Box(modifier = Modifier.padding(start = xDp + 8.dp, top = 8.dp)) {
+                                ChartTooltip(title = title, entries = entries)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (showLegend) {
+            ChartLegend(items = series.map { it.label to it.color })
+        }
+    }
+}
 
 /**
  * Small flow-row of color-dot + label chips, rendered below the chart when enabled.

--- a/komoui/src/commonMain/kotlin/com/komoui/components/charts/LineChart.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/charts/LineChart.kt
@@ -1,42 +1,17 @@
 package com.komoui.components.charts
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.komoui.themes.styles
-import kotlin.math.max
 
 /**
  * Line chart supporting one or more series.
@@ -47,14 +22,10 @@ import kotlin.math.max
  *
  * When [scrollable] is true the plot area scrolls horizontally and each
  * x-category is given at least [minColumnWidth] of space. The y-axis labels
- * stay pinned on the left. Drag-scrub tooltips are force-disabled in this
- * mode: `chartScrub` claims the gesture on pointer-down while
- * `Modifier.horizontalScroll` claims after touch-slop, so they can't coexist
- * without changing one strategy (see `Chart.md` in this directory, Pitfall #4,
- * for the long-press / tap-only alternatives).
+ * stay pinned on the left. Drag-scrub tooltips are force-disabled in this mode.
  *
  * Lines animate from left to right on first composition when [animate] is
- * true. When [showTooltip] is true (and [scrollable] is false), press-and-drag
+ * true. When [showTooltip] is true (and [scrollable] is false), drag
  * horizontally to scrub.
  */
 @Composable
@@ -71,195 +42,53 @@ fun LineChart(
     scrollable: Boolean = false,
     minColumnWidth: Dp = 56.dp,
 ) {
-    val textMeasurer = rememberTextMeasurer()
-    val labelStyle = chartLabelStyle()
-    val gridColor = MaterialTheme.styles.border
-    val labelColor = MaterialTheme.styles.mutedForeground
-    val indicatorColor = MaterialTheme.styles.mutedForeground
-    val dotInnerColor = MaterialTheme.styles.popover
-
-    val xLabels = series.firstOrNull()?.points?.map { it.x } ?: emptyList()
-    val columnCount = xLabels.size
-
-    val allValues = series.flatMap { s -> s.points.map { it.y } }
-    val minValue = allValues.minOrNull() ?: 0f
-    val maxValue = allValues.maxOrNull() ?: 1f
-    val domain = computeDomain(minValue, maxValue, axisOptions.yDomain)
-    val ticks = yTicks(domain, axisOptions.yTickCount)
-
     val density = LocalDensity.current
-    val insets = AxisInsetsDp()
-    val yAxisWidthDp = if (axisOptions.showY) insets.left else 0.dp
-    val bottomInsetPx = with(density) { (if (axisOptions.showX) insets.bottom else 0.dp).toPx() }
     val strokePx = with(density) { strokeWidth.toPx() }
     val dotPx = with(density) { 3.dp.toPx() }
+    val dotInnerColor = MaterialTheme.styles.popover
 
-    val progress = remember { Animatable(if (animate) 0f else 1f) }
-    LaunchedEffect(series) {
-        if (animate) {
-            progress.snapTo(0f)
-            progress.animateTo(1f, tween(durationMillis = 800))
-        } else {
-            progress.snapTo(1f)
-        }
-    }
+    ChartScaffold(
+        series = series,
+        modifier = modifier,
+        axisOptions = axisOptions,
+        showTooltip = showTooltip,
+        showLegend = showLegend,
+        chartHeight = chartHeight,
+        scrollable = scrollable,
+        minColumnWidth = minColumnWidth,
+        animate = animate,
+        animationDurationMillis = 800,
+    ) { scope ->
+        val plotRect = scope.plotRect
+        val slotWidth = scope.slotWidth
+        val clipRight = plotRect.left + plotRect.width * scope.progress
 
-    val scrub = rememberChartScrubState()
-    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-    val effectiveShowTooltip = showTooltip && !scrollable
-    val plotAxisOptions = remember(axisOptions) { axisOptions.copy(showY = false) }
-
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .semantics(mergeDescendants = true) {
-                contentDescription =
-                    chartSemanticsLabel(series.map { it.label }, series.firstOrNull()?.points?.size ?: 0)
-            }
-    ) {
-        Row(modifier = Modifier.fillMaxWidth().height(chartHeight)) {
-            if (axisOptions.showY) {
-                Canvas(modifier = Modifier.width(yAxisWidthDp).fillMaxHeight()) {
-                    val yAxisRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-                    drawYAxisOnly(
-                        yAxisRect = yAxisRect,
-                        yTicks = ticks,
-                        domain = domain,
-                        yLabelFormatter = axisOptions.yLabelFormatter,
-                        textMeasurer = textMeasurer,
-                        labelStyle = labelStyle,
-                        labelColor = labelColor,
-                    )
-                }
-            }
-
-            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxHeight()) {
-                val viewportDp = maxWidth
-                val rawContentDp = if (columnCount > 0) minColumnWidth * columnCount else viewportDp
-                val contentWidthDp =
-                    if (scrollable) maxOf(rawContentDp, viewportDp) else viewportDp
-                val needsScroll = scrollable && contentWidthDp > viewportDp
-
-                val scrollMod = if (needsScroll) {
-                    Modifier.horizontalScroll(rememberScrollState())
-                } else Modifier
-
-                Box(modifier = Modifier.fillMaxSize().then(scrollMod)) {
-                    val gestureMod = if (effectiveShowTooltip && columnCount > 0) {
-                        Modifier.chartScrub(
-                            columnCount = columnCount,
-                            plotLeft = 0f,
-                            plotWidth = canvasSize.width.toFloat(),
-                        ) { idx, pos ->
-                            scrub.index = idx
-                            scrub.pointer = pos
-                        }
-                    } else Modifier
-
-                    Canvas(
-                        modifier = Modifier
-                            .width(contentWidthDp)
-                            .fillMaxHeight()
-                            .onSizeChanged { canvasSize = it }
-                            .then(gestureMod),
-                    ) {
-                        val plotRect = computePlotRect(size, PlotInsets(0f, bottomInsetPx))
-
-                        drawAxesAndGrid(
-                            plotRect = plotRect,
-                            xLabels = xLabels,
-                            yTicks = ticks,
-                            domain = domain,
-                            axisOptions = plotAxisOptions,
-                            textMeasurer = textMeasurer,
-                            labelStyle = labelStyle,
-                            gridColor = gridColor,
-                            labelColor = labelColor,
-                        )
-
-                        if (columnCount == 0 || series.isEmpty()) return@Canvas
-
-                        val span = domain.endInclusive - domain.start
-                        if (span <= 0f) return@Canvas
-
-                        val slotWidth = plotRect.width / columnCount
-                        val clipRight = plotRect.left + plotRect.width * progress.value
-
-                        clipRect(
-                            left = 0f,
-                            top = 0f,
-                            right = clipRight,
-                            bottom = size.height,
-                        ) {
-                            series.forEach { s ->
-                                val points = seriesPositions(
-                                    s.points.map { it.y }, plotRect, domain, slotWidth,
-                                )
-                                val path = buildLinePath(points, smooth)
-                                drawPath(
-                                    path = path,
-                                    color = s.color,
-                                    style = Stroke(width = strokePx),
-                                )
-                            }
-                        }
-
-                        scrub.index?.let { idx ->
-                            drawScrubIndicator(plotRect, columnCount, idx, indicatorColor)
-                            series.forEach { s ->
-                                val p = s.points.getOrNull(idx) ?: return@forEach
-                                val cx = plotRect.left + slotWidth * (idx + 0.5f)
-                                val cy = plotRect.bottom -
-                                    ((p.y - domain.start) / span) * plotRect.height
-                                drawCircle(
-                                    color = s.color,
-                                    radius = dotPx + 1.5f,
-                                    center = Offset(cx, cy),
-                                )
-                                drawCircle(
-                                    color = dotInnerColor,
-                                    radius = dotPx,
-                                    center = Offset(cx, cy),
-                                )
-                            }
-                        }
-                    }
-
-                    val activeIdx = scrub.index
-                    if (effectiveShowTooltip &&
-                        activeIdx != null && activeIdx in 0 until columnCount
-                    ) {
-                        val slotWidthPx = canvasSize.width.toFloat() / columnCount
-                        val centerX = slotWidthPx * (activeIdx + 0.5f)
-                        val xDp = with(density) { centerX.toDp() }
-                        Box(modifier = Modifier.padding(start = xDp + 8.dp, top = 8.dp)) {
-                            ChartTooltip(
-                                title = xLabels.getOrNull(activeIdx).orEmpty(),
-                                entries = series.mapNotNull { s ->
-                                    val p = s.points.getOrNull(activeIdx)
-                                        ?: return@mapNotNull null
-                                    TooltipEntry(
-                                        label = s.label,
-                                        value = axisOptions.yLabelFormatter(p.y),
-                                        color = s.color,
-                                    )
-                                },
-                            )
-                        }
-                    }
-                }
+        clipRect(left = 0f, top = 0f, right = clipRight, bottom = size.height) {
+            series.forEach { s ->
+                // Clamp to the shared column count so a longer series doesn't draw past the plot.
+                val points = seriesPositions(
+                    s.points.take(scope.columnCount).map { it.y }, plotRect, scope.domain, slotWidth,
+                )
+                val path = buildLinePath(points, smooth)
+                drawPath(path = path, color = s.color, style = Stroke(width = strokePx))
             }
         }
 
-        if (showLegend) {
-            ChartLegend(items = series.map { it.label to it.color })
+        scope.scrubIndex?.let { idx ->
+            series.forEach { s ->
+                val p = s.points.getOrNull(idx) ?: return@forEach
+                val cx = plotRect.left + slotWidth * (idx + 0.5f)
+                val cy = plotRect.bottom - ((p.y - scope.domain.start) / scope.span) * plotRect.height
+                drawCircle(color = s.color, radius = dotPx + 1.5f, center = Offset(cx, cy))
+                drawCircle(color = dotInnerColor, radius = dotPx, center = Offset(cx, cy))
+            }
         }
     }
 }
 
 internal fun seriesPositions(
     values: List<Float>,
-    plotRect: androidx.compose.ui.geometry.Rect,
+    plotRect: Rect,
     domain: ClosedFloatingPointRange<Float>,
     slotWidth: Float,
 ): List<Offset> {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
@@ -98,7 +98,7 @@ private fun SidebarShell(
     }
 
     // Reset per-shell flags (rail) so this composition's `SidebarRail()` calls take effect.
-    slots.railEnabled = false
+    slots.railModifier = null
 
     val desktopShell: @Composable () -> Unit = {
         when (state.variant) {
@@ -166,10 +166,8 @@ private fun DesktopStandardSidebar(
             horizontalAlignment = if (state.isCollapsedIcon) Alignment.CenterHorizontally else Alignment.Start,
             content = content,
         )
-        // After `content()` composes, slots.railEnabled reflects whether the user called SidebarRail().
-        if (slots.railEnabled) {
-            RailOverlay(side = state.side)
-        }
+        // After `content()` composes, slots.railModifier reflects whether the user called SidebarRail().
+        slots.railModifier?.let { RailOverlay(side = state.side, modifier = it) }
     }
 }
 
@@ -182,8 +180,10 @@ private fun DesktopFloatingSidebar(
     val slots = LocalSidebarSlots.current!!
     val styles = MaterialTheme.styles
 
-    // Floating-in-icon adds a little for outer padding + border (matches React's calc(width-icon + 1rem + 2px)).
-    val targetWidth = if (state.isCollapsedIcon) state.widthIcon + 18.dp else state.width
+    // Floating-in-icon adds outer padding (1rem = 16.dp) + border (2.dp) to match React's
+    // calc(width-icon + 1rem + 2px).
+    val floatingIconExtraWidth = 16.dp + 2.dp
+    val targetWidth = if (state.isCollapsedIcon) state.widthIcon + floatingIconExtraWidth else state.width
     val animatedWidth by animateDpAsState(
         targetValue = targetWidth,
         animationSpec = state.animationSpec,
@@ -215,21 +215,19 @@ private fun DesktopFloatingSidebar(
             horizontalAlignment = if (state.isCollapsedIcon) Alignment.CenterHorizontally else Alignment.Start,
             content = content,
         )
-        if (slots.railEnabled) {
-            RailOverlay(side = state.side)
-        }
+        slots.railModifier?.let { RailOverlay(side = state.side, modifier = it) }
     }
 }
 
 @Composable
-private fun BoxScope.RailOverlay(side: SidebarSide) {
+private fun BoxScope.RailOverlay(side: SidebarSide, modifier: Modifier = Modifier) {
     val state = LocalSidebarState.current
     val styles = MaterialTheme.styles
 
     // ponytail: 20.dp hit strip, not the full 48.dp — a 48-wide rail would overlap sidebar
     // content along the whole edge. Widen further only if touch misses are reported.
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxHeight()
             .width(20.dp)
             .align(if (side == SidebarSide.Left) Alignment.CenterEnd else Alignment.CenterStart)
@@ -368,13 +366,13 @@ fun SidebarTrigger(
  * the sidebar shell so it can position absolutely on the outer edge.
  */
 @Composable
-fun SidebarRail(@Suppress("UNUSED_PARAMETER") modifier: Modifier = Modifier) {
+fun SidebarRail(modifier: Modifier = Modifier) {
     val slots = LocalSidebarSlots.current
         ?: error("SidebarRail must be used inside Sidebar.")
     val state = LocalSidebarState.current
     if (state.isMobile) return
     if (state.collapsible == SidebarCollapsible.Offcanvas) return
-    slots.railEnabled = true
+    slots.railModifier = modifier
 }
 
 // ---------------------------------------------------------------------------
@@ -542,8 +540,8 @@ fun SidebarInput(
 
 /**
  * Scrollable main content region of the sidebar. Takes the remaining vertical space inside
- * [Sidebar]. Scrolling is disabled when collapsed to icon to avoid scrollbar artifacts on
- * the narrow rail.
+ * [Sidebar]. Scrolls in every mode — including icon-collapsed — so long menus stay reachable
+ * on the narrow rail (matches shadcn).
  *
  * Must be called inside [Sidebar]'s [ColumnScope] so it can claim `weight(1f)`.
  */
@@ -554,7 +552,7 @@ fun ColumnScope.SidebarContent(
 ) {
     val state = LocalSidebarState.current
     val horizontal = if (state.isCollapsedIcon) 4.dp else 8.dp
-    val scrollModifier = if (state.isCollapsedIcon) Modifier else Modifier.verticalScroll(rememberScrollState())
+    val scrollModifier = Modifier.verticalScroll(rememberScrollState())
 
     Column(
         modifier = modifier

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/Sidebar.kt
@@ -52,6 +52,7 @@ import com.komoui.components.Input
 import com.komoui.components.InputVariant
 import com.komoui.themes.drawShadows
 import com.komoui.themes.komoStrings
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 
@@ -431,8 +432,7 @@ fun SidebarHeader(
             if (icon != null) icon()
             Text(
                 text = title,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.komoTypography.title,
                 color = MaterialTheme.styles.sidebarForeground,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -495,7 +495,7 @@ fun SidebarFooter(
             if (icon != null) icon()
             Text(
                 text = text,
-                fontSize = 12.sp,
+                style = MaterialTheme.komoTypography.label,
                 color = MaterialTheme.styles.mutedForeground,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarGroup.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarGroup.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.sp
 import com.komoui.components.Button
 import com.komoui.components.ButtonSize
 import com.komoui.components.ButtonVariant
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 
 /**
@@ -71,8 +72,7 @@ fun SidebarGroupLabel(
     Text(
         text = text,
         modifier = modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-        fontSize = 12.sp,
-        fontWeight = FontWeight.Medium,
+        style = MaterialTheme.komoTypography.labelMedium,
         color = MaterialTheme.styles.sidebarForeground.copy(alpha = 0.7f),
     )
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.komoui.components.Skeleton
+import com.komoui.themes.komoTypography
 import com.komoui.themes.radius
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
@@ -51,12 +52,12 @@ import com.komoui.utils.komoClickable
 enum class SidebarMenuButtonVariant { Default, Outline }
 enum class SidebarMenuButtonSize { Default, Small, Large }
 
-private data class MenuButtonMetrics(val height: Dp, val fontSize: Int, val iconSize: Dp)
+private data class MenuButtonMetrics(val height: Dp, val iconSize: Dp)
 
 private fun SidebarMenuButtonSize.metrics(): MenuButtonMetrics = when (this) {
-    SidebarMenuButtonSize.Default -> MenuButtonMetrics(height = 32.dp, fontSize = 14, iconSize = 18.dp)
-    SidebarMenuButtonSize.Small -> MenuButtonMetrics(height = 28.dp, fontSize = 12, iconSize = 16.dp)
-    SidebarMenuButtonSize.Large -> MenuButtonMetrics(height = 48.dp, fontSize = 14, iconSize = 20.dp)
+    SidebarMenuButtonSize.Default -> MenuButtonMetrics(height = 32.dp, iconSize = 18.dp)
+    SidebarMenuButtonSize.Small -> MenuButtonMetrics(height = 28.dp, iconSize = 16.dp)
+    SidebarMenuButtonSize.Large -> MenuButtonMetrics(height = 48.dp, iconSize = 20.dp)
 }
 
 // ---------------------------------------------------------------------------
@@ -229,8 +230,8 @@ fun SidebarMenuButton(
         Text(
             text = text,
             color = contentColor,
-            fontSize = metrics.fontSize.sp,
-            fontWeight = FontWeight.Medium,
+            style = if (size == SidebarMenuButtonSize.Small) MaterialTheme.komoTypography.labelMedium
+            else MaterialTheme.komoTypography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarMenu.kt
@@ -187,12 +187,13 @@ fun SidebarMenuButton(
         }
     }
 
-    val tooltipEnabled = tooltip != null && state.isCollapsedIcon && !state.isMobile
-    if (tooltipEnabled) {
+    val tooltipState = rememberTooltipState()
+    val tooltipText = tooltip
+    if (tooltipText != null && state.isCollapsedIcon && !state.isMobile) {
         TooltipBox(
             positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-            tooltip = { PlainTooltip { Text(tooltip!!) } },
-            state = rememberTooltipState(),
+            tooltip = { PlainTooltip { Text(tooltipText) } },
+            state = tooltipState,
             content = { button() },
         )
     } else {
@@ -249,7 +250,6 @@ fun SidebarMenuButton(
 fun SidebarMenuAction(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    @Suppress("UNUSED_PARAMETER") showOnHover: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val state = LocalSidebarState.current
@@ -381,7 +381,11 @@ fun SidebarMenuSubButton(
 
     val styles = MaterialTheme.styles
     val backgroundColor = if (isActive) styles.sidebarAccent else Color.Unspecified
-    val height = if (size == SidebarMenuButtonSize.Small) 24.dp else 28.dp
+    val height = when (size) {
+        SidebarMenuButtonSize.Small -> 24.dp
+        SidebarMenuButtonSize.Default -> 28.dp
+        SidebarMenuButtonSize.Large -> 32.dp
+    }
     val shape = RoundedCornerShape(MaterialTheme.radius.md)
 
     val clickHandler: () -> Unit = {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarProvider.kt
@@ -181,7 +181,9 @@ private fun SidebarLayoutImpl(state: SidebarState, slots: SidebarSlots) {
         CompositionLocalProvider(LocalLayoutDirection provides outerDirection) {
             ModalNavigationDrawer(
                 drawerState = drawerState,
-                gesturesEnabled = state.isOpenMobile,
+                // Enable swipe (edge-swipe-to-open + swipe-to-close), the Material drawer default;
+                // only None (non-collapsible) opts out.
+                gesturesEnabled = state.collapsible != SidebarCollapsible.None,
                 drawerContent = {
                     // Restore the host's direction inside drawer content so text doesn't mirror.
                     CompositionLocalProvider(LocalLayoutDirection provides hostDirection) {

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sidebar/SidebarState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -106,7 +107,6 @@ class SidebarState internal constructor(
         if (isMobile) onOpenMobileChange(true) else onOpenChange(true)
     }
 
-    internal fun setOpen(open: Boolean) = onOpenChange(open)
     internal fun setOpenMobile(open: Boolean) = onOpenMobileChange(open)
 }
 
@@ -131,8 +131,8 @@ internal class SidebarSlots {
     // a stale captured lambda.
     var sidebar: (@Composable () -> Unit)? by mutableStateOf(null)
     var inset: (@Composable () -> Unit)? by mutableStateOf(null)
-    /** Set by [SidebarRail] to opt the sidebar shell into rendering an outer-edge rail. */
-    var railEnabled: Boolean by mutableStateOf(false)
+    /** Modifier registered by [SidebarRail]; non-null opts the shell into rendering an outer-edge rail. */
+    var railModifier: Modifier? by mutableStateOf(null)
 }
 
 internal val LocalSidebarSlots = compositionLocalOf<SidebarSlots?> { null }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/ObserveAsEvent.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/ObserveAsEvent.kt
@@ -2,6 +2,8 @@ package com.komoui.components.sonner
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
@@ -9,19 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 
-/**
- * A Composable function that observes a [Flow] and treats each emission as a one-time event.
- *
- * This is useful for scenarios where you want to react to events from a ViewModel or another
- * part of your application without recomposing the entire Composable. The event is consumed
- * only when the Composable is in the `STARTED` lifecycle state.
- *
- * @param T The type of the event emitted by the flow.
- * @param flow The [Flow] of events to observe.
- * @param key1 An optional key to restart the effect if its value changes.
- * @param key2 Another optional key to restart the effect if its value changes.
- * @param onEvent A lambda that will be invoked for each event emitted by the [flow].
- */
 @Composable
 fun <T> ObserveAsEvent(
     flow: Flow<T>,
@@ -30,10 +19,11 @@ fun <T> ObserveAsEvent(
     onEvent: (T) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnEvent by rememberUpdatedState(onEvent)
     LaunchedEffect(lifecycleOwner.lifecycle, key1, key2, flow) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             withContext(Dispatchers.Main.immediate) {
-                flow.collect(onEvent)
+                flow.collect(currentOnEvent)
             }
         }
     }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -50,8 +50,8 @@ import com.komoui.utils.komoClickable
  */
 @Composable
 fun Sonner(
-    modifier: Modifier = Modifier,
     title: String,
+    modifier: Modifier = Modifier,
     subtitle: String? = null,
     actionLabel: String? = null,
     onActionClick: (() -> Unit)? = null,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -30,6 +30,7 @@ import com.komoui.components.ButtonVariant
 import com.komoui.themes.radius
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.komoStrings
+import com.komoui.themes.komoTypography
 import com.komoui.themes.styles
 import com.komoui.utils.komoClickable
 
@@ -133,15 +134,12 @@ fun Sonner(
         ) {
             Text(
                 text = title,
-                style = TextStyle(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp
-                )
+                style = MaterialTheme.komoTypography.titleEmphasis
             )
             if (subtitle != null) {
                 Text(
                     text = subtitle,
-                    style = TextStyle(fontSize = 14.sp)
+                    style = MaterialTheme.komoTypography.body
                 )
             }
         }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/Sonner.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.liveRegion
@@ -27,7 +28,6 @@ import com.komoui.components.Button
 import com.komoui.components.ButtonSize
 import com.komoui.components.ButtonVariant
 import com.komoui.themes.radius
-import androidx.compose.ui.graphics.Color
 import com.komoui.themes.KomoStyles
 import com.komoui.themes.komoStrings
 import com.komoui.themes.styles
@@ -155,11 +155,13 @@ private data class SonnerColors(
     val border: Color
 )
 
+// ponytail: fixed hues; shadcn rich-color toasts are theme-independent by design.
+// Promote to KomoStyles tokens if the theme grows semantic success/info/warning colors.
 private fun resolveSonnerColors(
     variant: SonnerVariant,
     styles: KomoStyles
 ): SonnerColors = when (variant) {
-    SonnerVariant.Default -> SonnerColors(
+    SonnerVariant.Default, SonnerVariant.Loading -> SonnerColors(
         containerColor = styles.snackbar,
         contentColor = styles.foreground,
         actionContentColor = styles.mutedForeground,
@@ -170,5 +172,23 @@ private fun resolveSonnerColors(
         contentColor = styles.destructiveForeground,
         actionContentColor = styles.destructiveForeground,
         border = styles.destructive
+    )
+    SonnerVariant.Success -> SonnerColors(
+        containerColor = styles.snackbar,
+        contentColor = Color(0xFF15803D),
+        actionContentColor = styles.mutedForeground,
+        border = Color(0xFF22C55E)
+    )
+    SonnerVariant.Info -> SonnerColors(
+        containerColor = styles.snackbar,
+        contentColor = Color(0xFF1D4ED8),
+        actionContentColor = styles.mutedForeground,
+        border = Color(0xFF3B82F6)
+    )
+    SonnerVariant.Warning -> SonnerColors(
+        containerColor = styles.snackbar,
+        contentColor = Color(0xFFB45309),
+        actionContentColor = styles.mutedForeground,
+        border = Color(0xFFF59E0B)
     )
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerHost.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerHost.kt
@@ -4,7 +4,30 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
+
+/**
+ * Creates and remembers a [SnackbarHostState] already wired to [SonnerProvider].
+ *
+ * Collects [SonnerProvider.events] for the lifetime of the composition and displays each event
+ * via [SnackbarHostState.showSonner] (which also invokes [SonnerAction.execute] on
+ * [SnackbarResult.ActionPerformed]). Pair the returned state with a [SonnerHost].
+ *
+ * Note: [SnackbarHostState] queues one toast at a time — a new event waits until the current
+ * snackbar is dismissed or times out.
+ */
+@Composable
+fun rememberSonnerHostState(): SnackbarHostState {
+    val hostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    ObserveAsEvent(SonnerProvider.events) { event ->
+        scope.launch { hostState.showSonner(event) }
+    }
+    return hostState
+}
 
 /**
  * A [SnackbarHost] wrapper that renders [SonnerVisualsImpl] visuals using the [Sonner] composable.
@@ -15,7 +38,6 @@ import androidx.compose.ui.Modifier
  * @param hostState The [SnackbarHostState] used to control snackbar display.
  * @param modifier The [Modifier] to apply to the host.
  */
-
 @Composable
 fun SonnerHost(
     hostState: SnackbarHostState,

--- a/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/components/sonner/SonnerVisualsImpl.kt
@@ -9,11 +9,17 @@ import androidx.compose.material3.SnackbarVisuals
  * Defines the visual style variants for the Sonner snackbar.
  *
  * - [Default] uses the standard snackbar colors from the theme.
- * - [Destructive] uses destructive/error colors to indicate a failure or warning.
+ * - [Destructive] uses destructive/error colors to indicate a failure.
+ * - [Success]/[Info]/[Warning] tint the border and content to match shadcn's rich-color toasts.
+ * - [Loading] uses neutral colors, intended for in-progress notifications.
  */
 enum class SonnerVariant {
     Default,
     Destructive,
+    Success,
+    Info,
+    Warning,
+    Loading,
 }
 
 /**

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/FieldDefaults.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/FieldDefaults.kt
@@ -1,13 +1,58 @@
 package com.komoui.themes
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * Shared sizing defaults for form-field components (Input, Select, Combobox, DatePicker) so their
- * heights stay consistent. Override per call site where a component exposes it.
+ * Colors for the trigger of a single-line form field (Select, Combobox, DatePicker). These share
+ * one shape because they render the same bordered box; the dropdown/popup surfaces stay themed via
+ * [KomoStyles] (popover tokens).
+ *
+ * @property text Color of the selected/entered value.
+ * @property placeholder Color of the placeholder shown when there is no value.
+ * @property border Border color at rest.
+ * @property focusedBorder Border color while focused/open.
+ * @property errorBorder Border color when the field is in error.
+ * @property supportingText Supporting text color.
+ * @property errorSupportingText Supporting text color when the field is in error.
+ */
+data class FieldColors(
+    val text: Color,
+    val placeholder: Color,
+    val border: Color,
+    val focusedBorder: Color,
+    val errorBorder: Color,
+    val supportingText: Color,
+    val errorSupportingText: Color,
+)
+
+/**
+ * Shared sizing and color defaults for form-field components (Input, Select, Combobox, DatePicker)
+ * so their heights and colors stay consistent. Override per call site via [colors].
  */
 object KomoFieldDefaults {
     /** Minimum interactive height of a single-line form field. */
     val Height: Dp = 48.dp
+
+    private fun colorsFrom(styles: KomoStyles): FieldColors = FieldColors(
+        text = styles.foreground,
+        placeholder = styles.mutedForeground,
+        border = styles.border,
+        focusedBorder = styles.ring,
+        errorBorder = styles.destructive,
+        supportingText = styles.mutedForeground,
+        errorSupportingText = styles.destructive,
+    )
+
+    /** [FieldColors] with the default KomoUI color scheme. */
+    @Composable
+    fun colors(): FieldColors = colorsFrom(MaterialTheme.styles)
+
+    /** [FieldColors] with the default scheme, mutated by [overrides]. */
+    @Composable
+    fun colors(overrides: FieldColors.() -> FieldColors): FieldColors =
+        colorsFrom(MaterialTheme.styles).overrides()
 }

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/FieldDefaults.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/FieldDefaults.kt
@@ -1,0 +1,13 @@
+package com.komoui.themes
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared sizing defaults for form-field components (Input, Select, Combobox, DatePicker) so their
+ * heights stay consistent. Override per call site where a component exposes it.
+ */
+object KomoFieldDefaults {
+    /** Minimum interactive height of a single-line form field. */
+    val Height: Dp = 48.dp
+}

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/KomoTheme.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/KomoTheme.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 
 internal val LocalKomoStyles = staticCompositionLocalOf<KomoStyles> { LightStyles }
 internal val LocalKomoRadius = staticCompositionLocalOf<KomoRadius> { Radius }
+internal val LocalKomoTypography = staticCompositionLocalOf { KomoTypography() }
 internal val LocalKomoDarkMode = staticCompositionLocalOf { false }
 
 
@@ -30,6 +31,7 @@ internal val LocalKomoDarkMode = staticCompositionLocalOf { false }
  * @param materialLightColors The Material 3 [ColorScheme] to be used for the light theme. Defaults to [lightColorScheme].
  * @param materialDarkColors The Material 3 [ColorScheme] to be used for the dark theme. Defaults to [darkColorScheme].
  * @param komoRadius The [KomoRadius] to be used. Defaults to [Radius].
+ * @param komoTypography The [KomoTypography] text tokens to be used. Defaults to [KomoTypography].
  * @param strings The [KomoStrings] (localizable labels/descriptions) to be used. Defaults to English.
  * @param typography The Material 3 [Typography] to be used. Defaults to [DefaultTypography].
  * @param content The composable content to be themed.
@@ -42,6 +44,7 @@ fun KomoTheme(
     materialLightColors: ColorScheme = lightColorScheme(),
     materialDarkColors: ColorScheme = darkColorScheme(),
     komoRadius: KomoRadius = Radius,
+    komoTypography: KomoTypography = KomoTypography(),
     strings: KomoStrings = KomoStrings(),
     typography: Typography? = null,
     content: @Composable () -> Unit,
@@ -51,6 +54,7 @@ fun KomoTheme(
     CompositionLocalProvider(
         LocalKomoStyles provides colors,
         LocalKomoRadius provides komoRadius,
+        LocalKomoTypography provides komoTypography,
         LocalKomoStrings provides strings,
         LocalKomoDarkMode provides isDarkTheme
     ) {
@@ -71,6 +75,11 @@ val MaterialTheme.radius: KomoRadius
     @Composable
     @ReadOnlyComposable
     get() = LocalKomoRadius.current
+
+val MaterialTheme.komoTypography: KomoTypography
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalKomoTypography.current
 
 val MaterialTheme.isDark: Boolean
     @Composable

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/Type.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/Type.kt
@@ -15,3 +15,26 @@ internal val DefaultTypography: Typography = Typography(
         letterSpacing = 0.5.sp
     )
 )
+
+/**
+ * KomoUI text tokens, mirroring shadcn's Tailwind text scale (xs/sm/base/lg) with the weights the
+ * components actually use. Access via `MaterialTheme.komoTypography` and prefer these over inline
+ * `fontSize`/`FontWeight` so text stays consistent and themeable.
+ *
+ * @property titleLarge 18sp SemiBold — section / dialog headings.
+ * @property title 16sp SemiBold — card and header titles.
+ * @property titleEmphasis 16sp Bold — emphasized titles (e.g. Sonner).
+ * @property body 14sp Normal — default body text and form fields.
+ * @property bodyMedium 14sp Medium — menu items, tabs, buttons.
+ * @property label 12sp Normal — captions, footers, helper text.
+ * @property labelMedium 12sp Medium — badges and small emphasized labels.
+ */
+data class KomoTypography(
+    val titleLarge: TextStyle = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.SemiBold),
+    val title: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
+    val titleEmphasis: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
+    val body: TextStyle = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Normal),
+    val bodyMedium: TextStyle = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium),
+    val label: TextStyle = TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Normal),
+    val labelMedium: TextStyle = TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Medium),
+)

--- a/komoui/src/commonMain/kotlin/com/komoui/themes/Type.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/themes/Type.kt
@@ -23,6 +23,7 @@ internal val DefaultTypography: Typography = Typography(
  *
  * @property titleLarge 18sp SemiBold — section / dialog headings.
  * @property title 16sp SemiBold — card and header titles.
+ * @property titleMedium 16sp Medium — calendar/accordion headers and nav labels.
  * @property titleEmphasis 16sp Bold — emphasized titles (e.g. Sonner).
  * @property body 14sp Normal — default body text and form fields.
  * @property bodyMedium 14sp Medium — menu items, tabs, buttons.
@@ -32,6 +33,7 @@ internal val DefaultTypography: Typography = Typography(
 data class KomoTypography(
     val titleLarge: TextStyle = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.SemiBold),
     val title: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
+    val titleMedium: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Medium),
     val titleEmphasis: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold),
     val body: TextStyle = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Normal),
     val bodyMedium: TextStyle = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium),

--- a/komoui/src/commonMain/kotlin/com/komoui/utils/PopupPositioning.kt
+++ b/komoui/src/commonMain/kotlin/com/komoui/utils/PopupPositioning.kt
@@ -1,0 +1,59 @@
+package com.komoui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
+import kotlin.math.max
+
+/** Horizontal placement of an anchored popup relative to its trigger. */
+enum class PopupAlignment { Start, Center }
+
+/**
+ * A [PopupPositionProvider] for dropdown-style popups (Select, Combobox, DatePicker, Popover).
+ *
+ * Anchors the popup below its trigger, flips it above when there isn't room below, and clamps it
+ * horizontally so it never runs off-screen. [Compose][androidx.compose.ui.window.Popup] passes the
+ * trigger's layout as `anchorBounds`, so callers don't need to measure the anchor position manually.
+ *
+ * @param gap Vertical gap (px) between trigger and popup.
+ * @param alignment Horizontal alignment of the popup relative to the trigger.
+ */
+class AnchoredPopupPositionProvider(
+    private val gap: Int,
+    private val alignment: PopupAlignment = PopupAlignment.Start,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val rawX = when (alignment) {
+            PopupAlignment.Start -> anchorBounds.left
+            PopupAlignment.Center -> anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
+        }
+        val x = rawX.coerceIn(0, max(0, windowSize.width - popupContentSize.width))
+        val below = anchorBounds.bottom + gap
+        val above = anchorBounds.top - popupContentSize.height - gap
+        val fitsBelow = below + popupContentSize.height <= windowSize.height
+        val y = if (fitsBelow || above < 0) below else above
+        return IntOffset(x, y)
+    }
+}
+
+/** Remembers an [AnchoredPopupPositionProvider], converting [gap] to pixels at the current density. */
+@Composable
+fun rememberAnchoredPopupPositionProvider(
+    gap: Dp = 4.dp,
+    alignment: PopupAlignment = PopupAlignment.Start,
+): AnchoredPopupPositionProvider {
+    val gapPx = with(LocalDensity.current) { gap.roundToPx() }
+    return remember(gapPx, alignment) { AnchoredPopupPositionProvider(gapPx, alignment) }
+}


### PR DESCRIPTION
Component API consistency & theming pass

Resolves the P2 component-review enhancements: unify theming, state hoisting, the customization API, and public parameter order across KomoUI. Also lands new capabilities on Sonner, Sidebar, and the charts.

✨ Features

- Sonner: rememberSonnerHostState() glue + Success/Info/Warning/Loading variants.
- Sidebar: swipe-to-open gesture, icon-mode scrolling, functional rail modifier slot.
- Form fields: isError + supportingText on Select, Combobox, DatePicker; enabled on DatePicker/DateRangePicker/Calendar.
- State hoisting: Calendar gains controlled month/onMonthChange (with initialMonth default); DataTable gains controlled sort + selectedKeys.

♻️ Refactors

- Theme typography: new KomoTypography tokens (titleLarge/title/titleMedium/titleEmphasis/body/bodyMedium/label/labelMedium) via MaterialTheme.komoTypography; swept ~20 components off inline fontSize/FontWeight. Unified field heights (KomoFieldDefaults.Height) and density-scaled chart draw constants.
- Charts: extracted shared ChartScaffold + unified series model; fixed scrub/tooltip behavior.
- Popup: extracted a shared anchored position provider (edge-flip + clamp) used by Select/Combobox/Popover.
- Color API: Switch and Checkbox now expose Defaults.colors(overrides) matching the Input pattern; renamed CheckboxColors → CheckboxStyle to stop shadowing the Material 3 type.
- Dropped dead CalendarStyle.background.

⚠️ Breaking changes

Public parameter order standardized (primary state/callback first, modifier second, required-before-default, trailing content last) across overlays, Avatar, Sonner, date pickers, and Carousel. All internal call sites use named arguments, so the only source-breaking change is Popover.onDismissRequest becoming required (was a nullable-default onDismiss).